### PR TITLE
chore: fix typo

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -65,7 +65,7 @@ $defs:
         properties:
           # TODO(cooper): re-use languages sub-enum?
           language:
-            type: string 
+            type: string
         $ref: "#/$defs/general-pattern-content"
   # EXPERIMENTAL
   new-source-pattern:
@@ -570,7 +570,7 @@ $defs:
     properties:
       metavariable-comparison:
         type: object
-        title: Compare metavariables with other metavariables or literals using constant propogation
+        title: Compare metavariables with other metavariables or literals using constant propagation
         properties:
           metavariable:
             type: string


### PR DESCRIPTION
someone's got to fix it ok

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
