### PR TITLE
Switch to ATD_string_wrap

### DIFF
--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -61,7 +61,7 @@ type rule = {
 }
 
 (* Rule_ID.t, "^[a-zA-Z0-9._-]*$" *)
-type rule_id = string wrap <ocaml module="ATDStringWrap.Ruleid">
+type rule_id = string wrap <ocaml module="Rule_ID">
 
 (* Version_info.t *)
 type version = string (* TODO  wrap <ocaml module="ATDStringWrap.Version"> *)

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -20,12 +20,12 @@
 (* Basic types *)
 (*****************************************************************************)
 
-type uuid = string wrap <ocaml module="ATDStringWrap.Uuidm">
+type uuid = string wrap <ocaml module="ATD_string_wrap.Uuidm">
 
-type sha256 = string wrap <ocaml module="ATDStringWrap.Sha256">
+type sha256 = string wrap <ocaml module="ATD_string_wrap.Sha256">
 
 (* GMT time (in osemgrep at least), in isoformat *)
-type datetime = string wrap <ocaml module="ATDStringWrap.Datetime">
+type datetime = string wrap <ocaml module="ATD_string_wrap.Datetime">
 
 type lang = string
 

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -71,16 +71,15 @@ type raw_json <ocaml module="Yojson.Basic" t="t"> = abstract
 (*****************************************************************************)
 
 (* File path. less: could convert directly to Path class of pathlib library for Python *)
-type fpath <ocaml attr="deriving show"> =
-  string wrap <ocaml module="ATDStringWrap.Fpath">
+type fpath <ocaml attr="deriving show"> = string wrap <ocaml module="ATD_string_wrap.Fpath">
 
-type uri = string wrap <ocaml module="ATDStringWrap.Uri">
+type uri = string wrap <ocaml module="ATD_string_wrap.Uri">
 
-type sha1 = string wrap <ocaml module="ATDStringWrap.Sha1">
+type sha1 = string wrap <ocaml module="ATD_string_wrap.Sha1">
 
-type uuid = string wrap <ocaml module="ATDStringWrap.Uuidm">
+type uuid = string wrap <ocaml module="ATD_string_wrap.Uuidm">
 
-(* GMT time (in osemgrep at least), in isoformat, TODO ATDStringWrap.Datetime *)
+(* GMT time (in osemgrep at least), in isoformat, TODO ATD_string_wrap.Datetime *)
 type datetime = string
 
 (*****************************************************************************)
@@ -124,7 +123,7 @@ type location
 type rule_id
      <ocaml attr="deriving show">
      <python decorator="dataclass(frozen=True)"> =
-  string wrap <ocaml module="ATDStringWrap.Ruleid">
+  string wrap <ocaml module="Rule_ID">
 
 (*
    Error = something wrong that must be fixed
@@ -1329,4 +1328,3 @@ type ci_scan_failure = {
     exit_code: int;
     stderr: string;
 }
-


### PR DESCRIPTION
test plan:
see related PR in semgrep


- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades