### PR TITLE
add multi-type syntax to metavariable-type rule

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -185,6 +185,14 @@ $defs:
                     type: string
                   type:
                     type: string
+              - required: [ metavariable, types ]
+                properties:
+                  metavariable:
+                    type: string
+                  types:
+                    type: array
+                    items:
+                      type: string
               - required: [ metavariable, analyzer ]
                 properties:
                   metavariable:
@@ -557,10 +565,18 @@ $defs:
           type:
             title: Type expression
             type: string
+          types:
+            title: Type expressions
+            type: array
+            items:
+              type: string
           language:
             type: string
-        required:
-          - type
+        oneOf:
+          - required:
+              - type
+          - required:
+              - types
         additionalProperties: false
     required:
       - metavariable-type


### PR DESCRIPTION
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
