### PR TITLE
feat: more granular pro engine config metrics

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -156,6 +156,33 @@ type pro_features = {
     ?diffDepth <ocaml mutable>: int option;
 }
 
+type analysis_type <ocaml attr="deriving show"> = [ 
+    | Intraprocedural 
+    | Interprocedural 
+    | Interfile
+]
+
+type secrets_config 
+     <ocaml attr="deriving show"> = {
+  permitted_origins: string;
+}
+
+type pro_config 
+     <ocaml attr="deriving show"> = {
+  analysis_type: analysis_type;
+  ?secrets_config: secrets_config option;
+  pro_langs: bool;
+}
+
+(* Since v1.54.0 *)
+type engine_config
+     <ocaml attr="deriving show">
+     <python decorator="dataclass(frozen=True)"> = [
+  | OSS
+  | PRO of pro_config
+]
+
+
 type misc = {
     (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
     features <ocaml mutable>: string list;
@@ -165,7 +192,10 @@ type misc = {
     ?numIgnored <ocaml mutable>: int option;
     ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;
     (* TODO: should be OSS | Pro, see semgrep_output_v1.atd engine_kind type *)
+    (* Still needed with engineConfig? *)
     ~engineRequested <python default="'OSS'"> <ocaml mutable>: string;
+    (* Since Semgrep 1.54.0 *)
+    ?engineConfig <ocaml mutable>: engine_config option;
     (* Since Semgrep 1.49.0 *)
     ?interfileLanguagesUsed: string list option;
   }

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -162,26 +162,28 @@ type analysis_type <ocaml attr="deriving show"> = [
     | Interfile
 ]
 
+type code_config <ocaml attr="deriving show"> = unit
+
+type secrets_origin <ocaml attr="deriving show"> = [ Any | Semgrep ]
 type secrets_config 
      <ocaml attr="deriving show"> = {
-  permitted_origins: string;
+  permitted_origins: secrets_origin;
 }
 
-type pro_config 
-     <ocaml attr="deriving show"> = {
-  analysis_type: analysis_type;
-  ?secrets_config: secrets_config option;
-  pro_langs: bool;
-}
+type supply_chain_config <ocaml attr="deriving show"> = unit
 
 (* Since v1.54.0 *)
 type engine_config
-     <ocaml attr="deriving show">
-     <python decorator="dataclass(frozen=True)"> = [
-  | OSS
-  | PRO of pro_config
-]
-
+     <ocaml attr="deriving show"> = {
+  analysis_type: analysis_type;
+  pro_langs: bool;
+  (* `Some c` where `c` is the config if the product was run.
+   * `None` if it was not run.
+   *)
+  ?code_config: code_config option;
+  ?secrets_config: secrets_config option;
+  ?supply_chain_config: supply_chain_config option;
+}
 
 type misc = {
     (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
@@ -192,7 +194,6 @@ type misc = {
     ?numIgnored <ocaml mutable>: int option;
     ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;
     (* TODO: should be OSS | Pro, see semgrep_output_v1.atd engine_kind type *)
-    (* Still needed with engineConfig? *)
     ~engineRequested <python default="'OSS'"> <ocaml mutable>: string;
     (* Since Semgrep 1.54.0 *)
     ?engineConfig <ocaml mutable>: engine_config option;

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -306,6 +306,34 @@ class Sha256:
 
 
 @dataclass
+class SecretsConfig:
+    """Original type: secrets_config = { ... }"""
+
+    permitted_origins: str
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'SecretsConfig':
+        if isinstance(x, dict):
+            return cls(
+                permitted_origins=_atd_read_string(x['permitted_origins']) if 'permitted_origins' in x else _atd_missing_json_field('SecretsConfig', 'permitted_origins'),
+            )
+        else:
+            _atd_bad_json('SecretsConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['permitted_origins'] = _atd_write_string(self.permitted_origins)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'SecretsConfig':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class RuleStats:
     """Original type: rule_stats = { ... }"""
 
@@ -363,6 +391,126 @@ class ProFeatures:
 
     @classmethod
     def from_json_string(cls, x: str) -> 'ProFeatures':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Intraprocedural:
+    """Original type: analysis_type = [ ... | Intraprocedural | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Intraprocedural'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Intraprocedural'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Interprocedural:
+    """Original type: analysis_type = [ ... | Interprocedural | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Interprocedural'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Interprocedural'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Interfile:
+    """Original type: analysis_type = [ ... | Interfile | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Interfile'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Interfile'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class AnalysisType:
+    """Original type: analysis_type = [ ... ]"""
+
+    value: Union[Intraprocedural, Interprocedural, Interfile]
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return self.value.kind
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'AnalysisType':
+        if isinstance(x, str):
+            if x == 'Intraprocedural':
+                return cls(Intraprocedural())
+            if x == 'Interprocedural':
+                return cls(Interprocedural())
+            if x == 'Interfile':
+                return cls(Interfile())
+            _atd_bad_json('AnalysisType', x)
+        _atd_bad_json('AnalysisType', x)
+
+    def to_json(self) -> Any:
+        return self.value.to_json()
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'AnalysisType':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class ProConfig:
+    """Original type: pro_config = { ... }"""
+
+    analysis_type: AnalysisType
+    pro_langs: bool
+    secrets_config: Optional[SecretsConfig] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'ProConfig':
+        if isinstance(x, dict):
+            return cls(
+                analysis_type=AnalysisType.from_json(x['analysis_type']) if 'analysis_type' in x else _atd_missing_json_field('ProConfig', 'analysis_type'),
+                pro_langs=_atd_read_bool(x['pro_langs']) if 'pro_langs' in x else _atd_missing_json_field('ProConfig', 'pro_langs'),
+                secrets_config=SecretsConfig.from_json(x['secrets_config']) if 'secrets_config' in x else None,
+            )
+        else:
+            _atd_bad_json('ProConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['analysis_type'] = (lambda x: x.to_json())(self.analysis_type)
+        res['pro_langs'] = _atd_write_bool(self.pro_langs)
+        if self.secrets_config is not None:
+            res['secrets_config'] = (lambda x: x.to_json())(self.secrets_config)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'ProConfig':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:
@@ -502,6 +650,76 @@ class ParseStat:
         return json.dumps(self.to_json(), **kw)
 
 
+@dataclass(frozen=True)
+class OSS:
+    """Original type: engine_config = [ ... | OSS | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'OSS'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'OSS'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass(frozen=True)
+class PRO:
+    """Original type: engine_config = [ ... | PRO of ... | ... ]"""
+
+    value: ProConfig
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'PRO'
+
+    def to_json(self) -> Any:
+        return ['PRO', (lambda x: x.to_json())(self.value)]
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass(frozen=True)
+class EngineConfig:
+    """Original type: engine_config = [ ... ]"""
+
+    value: Union[OSS, PRO]
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return self.value.kind
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'EngineConfig':
+        if isinstance(x, str):
+            if x == 'OSS':
+                return cls(OSS())
+            _atd_bad_json('EngineConfig', x)
+        if isinstance(x, List) and len(x) == 2:
+            cons = x[0]
+            if cons == 'PRO':
+                return cls(PRO(ProConfig.from_json(x[1])))
+            _atd_bad_json('EngineConfig', x)
+        _atd_bad_json('EngineConfig', x)
+
+    def to_json(self) -> Any:
+        return self.value.to_json()
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'EngineConfig':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
 @dataclass
 class Misc:
     """Original type: misc = { ... }"""
@@ -512,6 +730,7 @@ class Misc:
     numIgnored: Optional[int] = None
     ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
     engineRequested: str = field(default_factory=lambda: 'OSS')
+    engineConfig: Optional[EngineConfig] = None
     interfileLanguagesUsed: Optional[List[str]] = None
 
     @classmethod
@@ -524,6 +743,7 @@ class Misc:
                 numIgnored=_atd_read_int(x['numIgnored']) if 'numIgnored' in x else None,
                 ruleHashesWithFindings=_atd_read_assoc_object_into_list(_atd_read_int)(x['ruleHashesWithFindings']) if 'ruleHashesWithFindings' in x else None,
                 engineRequested=_atd_read_string(x['engineRequested']) if 'engineRequested' in x else 'OSS',
+                engineConfig=EngineConfig.from_json(x['engineConfig']) if 'engineConfig' in x else None,
                 interfileLanguagesUsed=_atd_read_list(_atd_read_string)(x['interfileLanguagesUsed']) if 'interfileLanguagesUsed' in x else None,
             )
         else:
@@ -541,6 +761,8 @@ class Misc:
         if self.ruleHashesWithFindings is not None:
             res['ruleHashesWithFindings'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.ruleHashesWithFindings)
         res['engineRequested'] = _atd_write_string(self.engineRequested)
+        if self.engineConfig is not None:
+            res['engineConfig'] = (lambda x: x.to_json())(self.engineConfig)
         if self.interfileLanguagesUsed is not None:
             res['interfileLanguagesUsed'] = _atd_write_list(_atd_write_string)(self.interfileLanguagesUsed)
         return res

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -285,6 +285,30 @@ class Uuid:
 
 
 @dataclass
+class SupplyChainConfig:
+    """Original type: supply_chain_config = { ... }"""
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'SupplyChainConfig':
+        if isinstance(x, dict):
+            return cls(
+            )
+        else:
+            _atd_bad_json('SupplyChainConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'SupplyChainConfig':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class Sha256:
     """Original type: sha256"""
 
@@ -306,23 +330,89 @@ class Sha256:
 
 
 @dataclass
+class Any_:
+    """Original type: secrets_origin = [ ... | Any | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Any_'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Any'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Semgrep:
+    """Original type: secrets_origin = [ ... | Semgrep | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Semgrep'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Semgrep'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class SecretsOrigin:
+    """Original type: secrets_origin = [ ... ]"""
+
+    value: Union[Any_, Semgrep]
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return self.value.kind
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'SecretsOrigin':
+        if isinstance(x, str):
+            if x == 'Any':
+                return cls(Any_())
+            if x == 'Semgrep':
+                return cls(Semgrep())
+            _atd_bad_json('SecretsOrigin', x)
+        _atd_bad_json('SecretsOrigin', x)
+
+    def to_json(self) -> Any:
+        return self.value.to_json()
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'SecretsOrigin':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class SecretsConfig:
     """Original type: secrets_config = { ... }"""
 
-    permitted_origins: str
+    permitted_origins: SecretsOrigin
 
     @classmethod
     def from_json(cls, x: Any) -> 'SecretsConfig':
         if isinstance(x, dict):
             return cls(
-                permitted_origins=_atd_read_string(x['permitted_origins']) if 'permitted_origins' in x else _atd_missing_json_field('SecretsConfig', 'permitted_origins'),
+                permitted_origins=SecretsOrigin.from_json(x['permitted_origins']) if 'permitted_origins' in x else _atd_missing_json_field('SecretsConfig', 'permitted_origins'),
             )
         else:
             _atd_bad_json('SecretsConfig', x)
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
-        res['permitted_origins'] = _atd_write_string(self.permitted_origins)
+        res['permitted_origins'] = (lambda x: x.to_json())(self.permitted_origins)
         return res
 
     @classmethod
@@ -391,126 +481,6 @@ class ProFeatures:
 
     @classmethod
     def from_json_string(cls, x: str) -> 'ProFeatures':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class Intraprocedural:
-    """Original type: analysis_type = [ ... | Intraprocedural | ... ]"""
-
-    @property
-    def kind(self) -> str:
-        """Name of the class representing this variant."""
-        return 'Intraprocedural'
-
-    @staticmethod
-    def to_json() -> Any:
-        return 'Intraprocedural'
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class Interprocedural:
-    """Original type: analysis_type = [ ... | Interprocedural | ... ]"""
-
-    @property
-    def kind(self) -> str:
-        """Name of the class representing this variant."""
-        return 'Interprocedural'
-
-    @staticmethod
-    def to_json() -> Any:
-        return 'Interprocedural'
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class Interfile:
-    """Original type: analysis_type = [ ... | Interfile | ... ]"""
-
-    @property
-    def kind(self) -> str:
-        """Name of the class representing this variant."""
-        return 'Interfile'
-
-    @staticmethod
-    def to_json() -> Any:
-        return 'Interfile'
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class AnalysisType:
-    """Original type: analysis_type = [ ... ]"""
-
-    value: Union[Intraprocedural, Interprocedural, Interfile]
-
-    @property
-    def kind(self) -> str:
-        """Name of the class representing this variant."""
-        return self.value.kind
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'AnalysisType':
-        if isinstance(x, str):
-            if x == 'Intraprocedural':
-                return cls(Intraprocedural())
-            if x == 'Interprocedural':
-                return cls(Interprocedural())
-            if x == 'Interfile':
-                return cls(Interfile())
-            _atd_bad_json('AnalysisType', x)
-        _atd_bad_json('AnalysisType', x)
-
-    def to_json(self) -> Any:
-        return self.value.to_json()
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'AnalysisType':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class ProConfig:
-    """Original type: pro_config = { ... }"""
-
-    analysis_type: AnalysisType
-    pro_langs: bool
-    secrets_config: Optional[SecretsConfig] = None
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'ProConfig':
-        if isinstance(x, dict):
-            return cls(
-                analysis_type=AnalysisType.from_json(x['analysis_type']) if 'analysis_type' in x else _atd_missing_json_field('ProConfig', 'analysis_type'),
-                pro_langs=_atd_read_bool(x['pro_langs']) if 'pro_langs' in x else _atd_missing_json_field('ProConfig', 'pro_langs'),
-                secrets_config=SecretsConfig.from_json(x['secrets_config']) if 'secrets_config' in x else None,
-            )
-        else:
-            _atd_bad_json('ProConfig', x)
-
-    def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        res['analysis_type'] = (lambda x: x.to_json())(self.analysis_type)
-        res['pro_langs'] = _atd_write_bool(self.pro_langs)
-        if self.secrets_config is not None:
-            res['secrets_config'] = (lambda x: x.to_json())(self.secrets_config)
-        return res
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'ProConfig':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:
@@ -650,46 +620,86 @@ class ParseStat:
         return json.dumps(self.to_json(), **kw)
 
 
-@dataclass(frozen=True)
-class OSS:
-    """Original type: engine_config = [ ... | OSS | ... ]"""
+@dataclass
+class CodeConfig:
+    """Original type: code_config = { ... }"""
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'CodeConfig':
+        if isinstance(x, dict):
+            return cls(
+            )
+        else:
+            _atd_bad_json('CodeConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'CodeConfig':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Intraprocedural:
+    """Original type: analysis_type = [ ... | Intraprocedural | ... ]"""
 
     @property
     def kind(self) -> str:
         """Name of the class representing this variant."""
-        return 'OSS'
+        return 'Intraprocedural'
 
     @staticmethod
     def to_json() -> Any:
-        return 'OSS'
+        return 'Intraprocedural'
 
     def to_json_string(self, **kw: Any) -> str:
         return json.dumps(self.to_json(), **kw)
 
 
-@dataclass(frozen=True)
-class PRO:
-    """Original type: engine_config = [ ... | PRO of ... | ... ]"""
-
-    value: ProConfig
+@dataclass
+class Interprocedural:
+    """Original type: analysis_type = [ ... | Interprocedural | ... ]"""
 
     @property
     def kind(self) -> str:
         """Name of the class representing this variant."""
-        return 'PRO'
+        return 'Interprocedural'
 
-    def to_json(self) -> Any:
-        return ['PRO', (lambda x: x.to_json())(self.value)]
+    @staticmethod
+    def to_json() -> Any:
+        return 'Interprocedural'
 
     def to_json_string(self, **kw: Any) -> str:
         return json.dumps(self.to_json(), **kw)
 
 
-@dataclass(frozen=True)
-class EngineConfig:
-    """Original type: engine_config = [ ... ]"""
+@dataclass
+class Interfile:
+    """Original type: analysis_type = [ ... | Interfile | ... ]"""
 
-    value: Union[OSS, PRO]
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Interfile'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Interfile'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class AnalysisType:
+    """Original type: analysis_type = [ ... ]"""
+
+    value: Union[Intraprocedural, Interprocedural, Interfile]
 
     @property
     def kind(self) -> str:
@@ -697,20 +707,62 @@ class EngineConfig:
         return self.value.kind
 
     @classmethod
-    def from_json(cls, x: Any) -> 'EngineConfig':
+    def from_json(cls, x: Any) -> 'AnalysisType':
         if isinstance(x, str):
-            if x == 'OSS':
-                return cls(OSS())
-            _atd_bad_json('EngineConfig', x)
-        if isinstance(x, List) and len(x) == 2:
-            cons = x[0]
-            if cons == 'PRO':
-                return cls(PRO(ProConfig.from_json(x[1])))
-            _atd_bad_json('EngineConfig', x)
-        _atd_bad_json('EngineConfig', x)
+            if x == 'Intraprocedural':
+                return cls(Intraprocedural())
+            if x == 'Interprocedural':
+                return cls(Interprocedural())
+            if x == 'Interfile':
+                return cls(Interfile())
+            _atd_bad_json('AnalysisType', x)
+        _atd_bad_json('AnalysisType', x)
 
     def to_json(self) -> Any:
         return self.value.to_json()
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'AnalysisType':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class EngineConfig:
+    """Original type: engine_config = { ... }"""
+
+    analysis_type: AnalysisType
+    pro_langs: bool
+    code_config: Optional[CodeConfig] = None
+    secrets_config: Optional[SecretsConfig] = None
+    supply_chain_config: Optional[SupplyChainConfig] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'EngineConfig':
+        if isinstance(x, dict):
+            return cls(
+                analysis_type=AnalysisType.from_json(x['analysis_type']) if 'analysis_type' in x else _atd_missing_json_field('EngineConfig', 'analysis_type'),
+                pro_langs=_atd_read_bool(x['pro_langs']) if 'pro_langs' in x else _atd_missing_json_field('EngineConfig', 'pro_langs'),
+                code_config=CodeConfig.from_json(x['code_config']) if 'code_config' in x else None,
+                secrets_config=SecretsConfig.from_json(x['secrets_config']) if 'secrets_config' in x else None,
+                supply_chain_config=SupplyChainConfig.from_json(x['supply_chain_config']) if 'supply_chain_config' in x else None,
+            )
+        else:
+            _atd_bad_json('EngineConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['analysis_type'] = (lambda x: x.to_json())(self.analysis_type)
+        res['pro_langs'] = _atd_write_bool(self.pro_langs)
+        if self.code_config is not None:
+            res['code_config'] = (lambda x: x.to_json())(self.code_config)
+        if self.secrets_config is not None:
+            res['secrets_config'] = (lambda x: x.to_json())(self.secrets_config)
+        if self.supply_chain_config is not None:
+            res['supply_chain_config'] = (lambda x: x.to_json())(self.supply_chain_config)
+        return res
 
     @classmethod
     def from_json_string(cls, x: str) -> 'EngineConfig':


### PR DESCRIPTION
Creates a new metrics type which is closely aligned with osemgrep's Engine_type.t which allows for more precise tracking of the engine feature matrix. This is needed compared to a simple enumeration since we have more orthogonal features than previously. For instance, we can now perform analysis on at least two axes (within pro):
    (1) secrets valdiation [enabled <-> disabled];
    (2) dataflow [none <-> ... <-> interfile]
Creating a new enum entry for each possible permutation is not futureproof (and is ugly), so we need a more complex type here.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
