### PR TITLE
fix: mypy issues after #202

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -162,17 +162,13 @@ type analysis_type <ocaml attr="deriving show"> = [
     | Interfile
 ]
 
-type code_config <ocaml attr="deriving show"> = unit
-
 type secrets_origin <ocaml attr="deriving show"> = [ Any | Semgrep ]
 type secrets_config 
      <ocaml attr="deriving show"> = {
   permitted_origins: secrets_origin;
 }
 
-type supply_chain_config <ocaml attr="deriving show"> = unit
-
-(* Since v1.54.0 *)
+(* Since v1.55.0 *)
 type engine_config
      <ocaml attr="deriving show"> = {
   analysis_type: analysis_type;
@@ -180,9 +176,19 @@ type engine_config
   (* `Some c` where `c` is the config if the product was run.
    * `None` if it was not run.
    *)
-  ?code_config: code_config option;
+  (* Ideally these would be <config type> options, and just have those config
+   * types be aliased to unit for now, but atd doesn't generate correct code
+   * for python when unit is alised (to_json/from_json are wrong and try to
+   * call methods on a fake Unit class). In the alternative, {} doesn't work
+   * either since it is not valid OCaml syntax (in my dreams equivalent to
+   * unit) as empty records are not permitted.
+   *
+   * As an alternative, they could be bools for now, but we want these fields
+   * to be optional for compability reasons.
+   *)
+  ?code_config: bool option;
   ?secrets_config: secrets_config option;
-  ?supply_chain_config: supply_chain_config option;
+  ?supply_chain_config: bool option;
 }
 
 type misc = {

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -162,11 +162,24 @@ type analysis_type <ocaml attr="deriving show"> = [
     | Interfile
 ]
 
+(* Ideally this and supply_chain_config would be unit or empty records,  but
+ * atd doesn't generate correct code for python when unit is aliased
+ * (to_json/from_json are wrong and try to call methods on a fake Unit class).
+ * In the alternative, {} doesn't work either since atd just passes it through
+ * instead of converting to unit and it is not valid OCaml syntax.
+ *
+ * So we have a "reserved for future use" (RFU) field just to act as a
+ * placeholder.
+ *)
+type code_config  <ocaml attr="deriving show"> = { ?_rfu: int option; }
+
 type secrets_origin <ocaml attr="deriving show"> = [ Any | Semgrep ]
 type secrets_config 
      <ocaml attr="deriving show"> = {
   permitted_origins: secrets_origin;
 }
+
+type supply_chain_config  <ocaml attr="deriving show"> = { ?_rfu: int option; }
 
 (* Since v1.55.0 *)
 type engine_config
@@ -176,19 +189,9 @@ type engine_config
   (* `Some c` where `c` is the config if the product was run.
    * `None` if it was not run.
    *)
-  (* Ideally these would be <config type> options, and just have those config
-   * types be aliased to unit for now, but atd doesn't generate correct code
-   * for python when unit is alised (to_json/from_json are wrong and try to
-   * call methods on a fake Unit class). In the alternative, {} doesn't work
-   * either since it is not valid OCaml syntax (in my dreams equivalent to
-   * unit) as empty records are not permitted.
-   *
-   * As an alternative, they could be bools for now, but we want these fields
-   * to be optional for compability reasons.
-   *)
-  ?code_config: bool option;
+  ?code_config: code_config option;
   ?secrets_config: secrets_config option;
-  ?supply_chain_config: bool option;
+  ?supply_chain_config: supply_chain_config option;
 }
 
 type misc = {

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -285,6 +285,35 @@ class Uuid:
 
 
 @dataclass
+class SupplyChainConfig:
+    """Original type: supply_chain_config = { ... }"""
+
+    _rfu: Optional[int] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'SupplyChainConfig':
+        if isinstance(x, dict):
+            return cls(
+                _rfu=_atd_read_int(x['_rfu']) if '_rfu' in x else None,
+            )
+        else:
+            _atd_bad_json('SupplyChainConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        if self._rfu is not None:
+            res['_rfu'] = _atd_write_int(self._rfu)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'SupplyChainConfig':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class Sha256:
     """Original type: sha256"""
 
@@ -597,6 +626,35 @@ class ParseStat:
 
 
 @dataclass
+class CodeConfig:
+    """Original type: code_config = { ... }"""
+
+    _rfu: Optional[int] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'CodeConfig':
+        if isinstance(x, dict):
+            return cls(
+                _rfu=_atd_read_int(x['_rfu']) if '_rfu' in x else None,
+            )
+        else:
+            _atd_bad_json('CodeConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        if self._rfu is not None:
+            res['_rfu'] = _atd_write_int(self._rfu)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'CodeConfig':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class Intraprocedural:
     """Original type: analysis_type = [ ... | Intraprocedural | ... ]"""
 
@@ -687,9 +745,9 @@ class EngineConfig:
 
     analysis_type: AnalysisType
     pro_langs: bool
-    code_config: Optional[bool] = None
+    code_config: Optional[CodeConfig] = None
     secrets_config: Optional[SecretsConfig] = None
-    supply_chain_config: Optional[bool] = None
+    supply_chain_config: Optional[SupplyChainConfig] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'EngineConfig':
@@ -697,9 +755,9 @@ class EngineConfig:
             return cls(
                 analysis_type=AnalysisType.from_json(x['analysis_type']) if 'analysis_type' in x else _atd_missing_json_field('EngineConfig', 'analysis_type'),
                 pro_langs=_atd_read_bool(x['pro_langs']) if 'pro_langs' in x else _atd_missing_json_field('EngineConfig', 'pro_langs'),
-                code_config=_atd_read_bool(x['code_config']) if 'code_config' in x else None,
+                code_config=CodeConfig.from_json(x['code_config']) if 'code_config' in x else None,
                 secrets_config=SecretsConfig.from_json(x['secrets_config']) if 'secrets_config' in x else None,
-                supply_chain_config=_atd_read_bool(x['supply_chain_config']) if 'supply_chain_config' in x else None,
+                supply_chain_config=SupplyChainConfig.from_json(x['supply_chain_config']) if 'supply_chain_config' in x else None,
             )
         else:
             _atd_bad_json('EngineConfig', x)
@@ -709,11 +767,11 @@ class EngineConfig:
         res['analysis_type'] = (lambda x: x.to_json())(self.analysis_type)
         res['pro_langs'] = _atd_write_bool(self.pro_langs)
         if self.code_config is not None:
-            res['code_config'] = _atd_write_bool(self.code_config)
+            res['code_config'] = (lambda x: x.to_json())(self.code_config)
         if self.secrets_config is not None:
             res['secrets_config'] = (lambda x: x.to_json())(self.secrets_config)
         if self.supply_chain_config is not None:
-            res['supply_chain_config'] = _atd_write_bool(self.supply_chain_config)
+            res['supply_chain_config'] = (lambda x: x.to_json())(self.supply_chain_config)
         return res
 
     @classmethod

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -285,30 +285,6 @@ class Uuid:
 
 
 @dataclass
-class SupplyChainConfig:
-    """Original type: supply_chain_config = { ... }"""
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'SupplyChainConfig':
-        if isinstance(x, dict):
-            return cls(
-            )
-        else:
-            _atd_bad_json('SupplyChainConfig', x)
-
-    def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        return res
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'SupplyChainConfig':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
 class Sha256:
     """Original type: sha256"""
 
@@ -621,30 +597,6 @@ class ParseStat:
 
 
 @dataclass
-class CodeConfig:
-    """Original type: code_config = { ... }"""
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'CodeConfig':
-        if isinstance(x, dict):
-            return cls(
-            )
-        else:
-            _atd_bad_json('CodeConfig', x)
-
-    def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        return res
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'CodeConfig':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
 class Intraprocedural:
     """Original type: analysis_type = [ ... | Intraprocedural | ... ]"""
 
@@ -735,9 +687,9 @@ class EngineConfig:
 
     analysis_type: AnalysisType
     pro_langs: bool
-    code_config: Optional[CodeConfig] = None
+    code_config: Optional[bool] = None
     secrets_config: Optional[SecretsConfig] = None
-    supply_chain_config: Optional[SupplyChainConfig] = None
+    supply_chain_config: Optional[bool] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'EngineConfig':
@@ -745,9 +697,9 @@ class EngineConfig:
             return cls(
                 analysis_type=AnalysisType.from_json(x['analysis_type']) if 'analysis_type' in x else _atd_missing_json_field('EngineConfig', 'analysis_type'),
                 pro_langs=_atd_read_bool(x['pro_langs']) if 'pro_langs' in x else _atd_missing_json_field('EngineConfig', 'pro_langs'),
-                code_config=CodeConfig.from_json(x['code_config']) if 'code_config' in x else None,
+                code_config=_atd_read_bool(x['code_config']) if 'code_config' in x else None,
                 secrets_config=SecretsConfig.from_json(x['secrets_config']) if 'secrets_config' in x else None,
-                supply_chain_config=SupplyChainConfig.from_json(x['supply_chain_config']) if 'supply_chain_config' in x else None,
+                supply_chain_config=_atd_read_bool(x['supply_chain_config']) if 'supply_chain_config' in x else None,
             )
         else:
             _atd_bad_json('EngineConfig', x)
@@ -757,11 +709,11 @@ class EngineConfig:
         res['analysis_type'] = (lambda x: x.to_json())(self.analysis_type)
         res['pro_langs'] = _atd_write_bool(self.pro_langs)
         if self.code_config is not None:
-            res['code_config'] = (lambda x: x.to_json())(self.code_config)
+            res['code_config'] = _atd_write_bool(self.code_config)
         if self.secrets_config is not None:
             res['secrets_config'] = (lambda x: x.to_json())(self.secrets_config)
         if self.supply_chain_config is not None:
-            res['supply_chain_config'] = (lambda x: x.to_json())(self.supply_chain_config)
+            res['supply_chain_config'] = _atd_write_bool(self.supply_chain_config)
         return res
 
     @classmethod


### PR DESCRIPTION
See https://semgrepinc.slack.com/archives/C01NXGX2EHZ/p1703115761745179

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
