### PR TITLE
Tentative fixes for the atddiff check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,7 +40,7 @@ jobs:
         atddiff --version
 
         # run the checks
-        echo -ne 'Backwards compatability summary:\n\n```' > summary-00-header.txt
+        echo -ne 'Backwards compatibility summary:\n\n```' > summary-00-header.txt
         echo '```' >> summary-20-footer.txt
 
         # fail if check command fails

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,7 @@ jobs:
         set -x
 
         git config --global --add safe.directory "$(pwd)"
-        
+
         # github actions sets HOME=/home/github where we don't have an opam env
         eval $(HOME=/root opam env)
         apk add jq
@@ -42,7 +42,10 @@ jobs:
         # run the checks
         echo -ne 'Backwards compatability summary:\n\n```' > summary-00-header.txt
         echo '```' >> summary-20-footer.txt
-        ./scripts/check-backwards-compatability.sh | tee summary-10-body.txt
+
+        # fail if check command fails
+        set -o pipefail
+        ./scripts/check-backwards-compatibility | tee summary-10-body.txt
 
     - uses: marocchino/sticky-pull-request-comment@v2
       if: ${{ !cancelled() }}

--- a/scripts/check-backwards-compatibility
+++ b/scripts/check-backwards-compatibility
@@ -12,7 +12,14 @@
 #    - Diff the two diffs to see if new issues were introduced
 set -euo pipefail
 
-minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
+version_url="https://semgrep.dev/api/check-version"
+min_version=$(curl -s "$version_url" | jq -r '.versions.minimum')
+if [[ -z "$min_version" ]]; then
+  echo "Failed to obtain minimum supported version from $version_url" >&2
+  exit 1
+fi
+
+minimum="v${min_version}"
 tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
 
 checked=("dummy")
@@ -27,22 +34,27 @@ for tag in $tags; do
 
     set +e # do our own error handling for a bit
     echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
-    git difftool --trust-exit-code -x 'atddiff --no-locations --backward' -y "$tag" "origin/main" semgrep_output_v1.atd > before.txt
+    # I'm getting an exit code 128 when atddiff returns 3 (as of git 2.43.0),
+    # contrary to what 'git difftool --help' promises for '--trust-exit-code'.
+    # I'd report the bug if it was easier. -- Martin
+    git difftool --trust-exit-code -x 'atddiff --no-locations --backward' -y \
+        "$tag" "origin/main" -- semgrep_output_v1.atd > before.txt
     ret=$?
     if [ "$ret" -ge 1 ] && [ "$ret" -le 2 ]; then
-        echo "ERROR: atddiff had an error: $?"
+        echo "ERROR: atddiff had an error: $ret"
         cat before.txt
         exit 1
     fi
-    git difftool --trust-exit-code -x 'atddiff --no-locations --backward' -y "$tag" "HEAD" semgrep_output_v1.atd > after.txt
+    git difftool --trust-exit-code -x 'atddiff --no-locations --backward' -y \
+        "$tag" "HEAD" -- semgrep_output_v1.atd > after.txt
     ret=$?
     if [ "$ret" -ge 1 ] && [ "$ret" -le 2 ]; then
-        echo "ERROR: atddiff had an error: $?"
+        echo "ERROR: atddiff had an error: $ret"
         cat after.txt
         exit 1
     fi
 
-    diff -u <(cat before.txt) <(cat after.txt)
+    diff -u before.txt after.txt
     if [ "$?" -ne 0 ]; then
         echo "ERROR: semgrep_output_v1.atd is not backward compatible with $tag"
         errors=$((errors + 1))


### PR DESCRIPTION
I guessed possible problems from CI error logs and fixed the following:

* The GHA script may be running with Bash without `-o pipefail` which would cause the check command within a pipe to not make the CI check fail. I don't know if this problem really happened but specifying `-o pipefail` regardless of how GHA invokes Bash removes doubt.
* If the JSON containing the minimum version ID can't be fetched, it now results in a clear error message rather than an invalid tag `v` and strange error later. I saw this error in https://github.com/semgrep/semgrep-interfaces/actions/runs/7036193485/job/19148273385?pr=199

test plan:
* check out this branch.
* add a dummy required field to a record such as adding `floobz: int;` to the `location` type definition.
* commit this change
* run the script with `./scripts/check-backwards-compatibility`
* check the exit status with `echo $?`; it should be nonzero. Ideally, it should be 3, but an apparent bug in `git difftool` causes it to be 128.
* undo the dummy commit

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
