### PR TITLE
feat(metrics): add findings by product breakdown

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -200,6 +200,7 @@ type misc = {
     (* Since semgrep 1.46 *)
     ?proFeatures <ocaml mutable>: pro_features option;
     ?numFindings <ocaml mutable>: int option;
+    ?numFindingsByProduct <ocaml mutable>: (string * int) list <json repr="object"> option;
     ?numIgnored <ocaml mutable>: int option;
     ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;
     (* TODO: should be OSS | Pro, see semgrep_output_v1.atd engine_kind type *)

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -789,6 +789,7 @@ class Misc:
     features: List[str]
     proFeatures: Optional[ProFeatures] = None
     numFindings: Optional[int] = None
+    numFindingsByProduct: Optional[List[Tuple[str, int]]] = None
     numIgnored: Optional[int] = None
     ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
     engineRequested: str = field(default_factory=lambda: 'OSS')
@@ -802,6 +803,7 @@ class Misc:
                 features=_atd_read_list(_atd_read_string)(x['features']) if 'features' in x else _atd_missing_json_field('Misc', 'features'),
                 proFeatures=ProFeatures.from_json(x['proFeatures']) if 'proFeatures' in x else None,
                 numFindings=_atd_read_int(x['numFindings']) if 'numFindings' in x else None,
+                numFindingsByProduct=_atd_read_assoc_object_into_list(_atd_read_int)(x['numFindingsByProduct']) if 'numFindingsByProduct' in x else None,
                 numIgnored=_atd_read_int(x['numIgnored']) if 'numIgnored' in x else None,
                 ruleHashesWithFindings=_atd_read_assoc_object_into_list(_atd_read_int)(x['ruleHashesWithFindings']) if 'ruleHashesWithFindings' in x else None,
                 engineRequested=_atd_read_string(x['engineRequested']) if 'engineRequested' in x else 'OSS',
@@ -818,6 +820,8 @@ class Misc:
             res['proFeatures'] = (lambda x: x.to_json())(self.proFeatures)
         if self.numFindings is not None:
             res['numFindings'] = _atd_write_int(self.numFindings)
+        if self.numFindingsByProduct is not None:
+            res['numFindingsByProduct'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.numFindingsByProduct)
         if self.numIgnored is not None:
             res['numIgnored'] = _atd_write_int(self.numIgnored)
         if self.ruleHashesWithFindings is not None:


### PR DESCRIPTION
Helps PA-3312.

This breakdown will allow us to calculate the number of findings per bytes of code scanned per product to understand users better.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
