### PR TITLE
Rename PatUnderscore to PatWildcard

### DIFF
--- a/ast_generic_v1.atd
+++ b/ast_generic_v1.atd
@@ -557,7 +557,7 @@ type pattern = [
   | PatKeyVal of (pattern * pattern) (* a kind of PatTuple *)
 
   (* special case of PatId *)
-  | PatUnderscore of tok
+  | PatWildcard of tok
 
   (* OCaml *)
   | PatDisj  of (pattern * pattern) (* also abused for catch in Java *)

--- a/ast_generic_v1_j.ml
+++ b/ast_generic_v1_j.ml
@@ -7477,8 +7477,8 @@ and write_pattern = (
             Buffer.add_char ob ']';
         ) ob x;
         Buffer.add_char ob ']'
-      | `PatUnderscore x ->
-        Buffer.add_string ob "[\"PatUnderscore\",";
+      | `PatWildcard x ->
+        Buffer.add_string ob "[\"PatWildcard\",";
         (
           write_tok
         ) ob x;
@@ -19842,7 +19842,7 @@ and read_pattern = (
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `PatKeyVal x
-            | "PatUnderscore" ->
+            | "PatWildcard" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
                   read_tok
@@ -19850,7 +19850,7 @@ and read_pattern = (
               in
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
-              `PatUnderscore x
+              `PatWildcard x
             | "PatDisj" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
@@ -20361,7 +20361,7 @@ and read_pattern = (
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_rbr p lb;
               `PatKeyVal x
-            | "PatUnderscore" ->
+            | "PatWildcard" ->
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
@@ -20371,7 +20371,7 @@ and read_pattern = (
               in
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_rbr p lb;
-              `PatUnderscore x
+              `PatWildcard x
             | "PatDisj" ->
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_comma p lb;


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
