### PR TITLE
chore: tag Elixir as a pro language

### DIFF
--- a/Language.ml
+++ b/Language.ml
@@ -208,7 +208,7 @@ let list = [
   excluded_exts = [];
   reverse_exts = None;
   shebangs = [];
-  tags = [];
+  tags = [{|is_proprietary|}];
 };
 {
   id = Go;

--- a/generate.py
+++ b/generate.py
@@ -292,7 +292,8 @@ not ambiguous is welcome here.
         keys=["ex", "elixir"],
         exts=[".ex", ".exs"],
         maturity=Maturity.ALPHA,
-        shebangs=[]
+        shebangs=[],
+        tags=["is_proprietary"]
     ),
     Language(
         comment="",

--- a/lang.json
+++ b/lang.json
@@ -198,7 +198,9 @@
     "reverse_exts": null,
     "shebangs": [],
     "is_target_language": true,
-    "tags": []
+    "tags": [
+      "is_proprietary"
+    ]
   },
   {
     "id": "go",


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
