### PR TITLE
add go_package to the protobuf generator

### DIFF
--- a/scripts/jsonschema2protobuf.py
+++ b/scripts/jsonschema2protobuf.py
@@ -183,6 +183,7 @@ def convert(contents, prefix=None, package=None):
 
     if package:
         lines.append(f"package {package};\n")
+        lines.append(f"option go_package = \"{package}\";\n")
 
     json_contents = json.loads(contents)
     definitions = json_contents.get("definitions", {})

--- a/semgrep_output_v1.proto
+++ b/semgrep_output_v1.proto
@@ -8,6 +8,8 @@ import "google/protobuf/any.proto";
 
 package semgrep_output_v1;
 
+option go_package = "semgrep_output_v1";
+
 message CliOutput {
   string version = 508888787;
   repeated CliError errors = 179828283;


### PR DESCRIPTION
Setting this makes it considerably easier for golang users to use the protobuf generated code.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
