### PR TITLE
add CI check to ensure that generated code is up-to-date

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
 - [ ] I made sure we're still backward compatible with old versions of the CLI.
       For example, the Semgrep backend need to still be able to *consume* data generated
 	  by Semgrep 1.17.0.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,6 @@ jobs:
       uses: actions/checkout@v4
     - name: Ensure generated code is up-to-date
       id: generate
-      shell: bash
       run: |
         eval "$(opam env)"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,8 @@ jobs:
       id: generate
       shell: bash
       run: |
+        eval "$(opam env)"
+
         # Install deps
         make setup
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,24 @@ permissions:
   pull-requests: write # for comments
 
 jobs:
+  generate:
+    runs-on: ubuntu-latest
+    container: returntocorp/ocaml:alpine
+    steps:
+    - name: Checkout tree
+      uses: actions/checkout@v4
+    - name: Ensure generated code is up-to-date
+      id: generate
+      shell: bash
+      run: |
+        # Install deps
+        make setup
+
+        # Generate code
+        make
+
+        # Fail if there is a diff
+        git diff --exit-code
   compatibility:
     runs-on: ubuntu-latest
     container: returntocorp/ocaml:alpine


### PR DESCRIPTION
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
