### PR TITLE
feat!: remove deprecated postprocessor syntax

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -827,8 +827,6 @@ properties:
             # EXPERIMENTAL
             - join
             - extract
-            # EXPERIMENTAL
-            - semgrep_internal_postprocessor
         languages:
           $ref: "#/$defs/languages"
         paths:


### PR DESCRIPTION
Removes the `mode` setting for the old postprocessor syntax we replaced 3-4 months ago. This syntax is undocumented and unused internally; externally it was never part of a documented public API.

BREAKING CHANGE: This means we may now reject rules with `mode: semgrep_internal_postprocessor`

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
