### PR TITLE
add: os and isjs environment metrics

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -66,8 +66,10 @@ type payload = {
 type environment = {
     (* semgrep version *)
     version <ocaml mutable>: string;
-    os: string;
-    isJS <ocaml mutable>: bool;
+    (* Since Semgrep 1.59 *)
+    os: string; (* e.g. linux *)
+    (* Since Semgrep 1.59 *)
+    isTranspiledJS <ocaml mutable>: bool;
     projectHash <ocaml mutable>: sha256 nullable;
     configNamesHash <python default="Sha256hash('')"> <ocaml mutable>: sha256;
     ?rulesHash <ocaml mutable>: sha256 option;

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -66,6 +66,8 @@ type payload = {
 type environment = {
     (* semgrep version *)
     version <ocaml mutable>: string;
+    os: string;
+    isJS <ocaml mutable>: bool;
     projectHash <ocaml mutable>: sha256 nullable;
     configNamesHash <python default="Sha256hash('')"> <ocaml mutable>: sha256;
     ?rulesHash <ocaml mutable>: sha256 option;

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -946,7 +946,7 @@ class Environment:
 
     version: str
     os: str
-    isJS: bool
+    isTranspiledJS: bool
     projectHash: Optional[Sha256]
     configNamesHash: Sha256
     ci: Optional[str]
@@ -961,7 +961,7 @@ class Environment:
             return cls(
                 version=_atd_read_string(x['version']) if 'version' in x else _atd_missing_json_field('Environment', 'version'),
                 os=_atd_read_string(x['os']) if 'os' in x else _atd_missing_json_field('Environment', 'os'),
-                isJS=_atd_read_bool(x['isJS']) if 'isJS' in x else _atd_missing_json_field('Environment', 'isJS'),
+                isTranspiledJS=_atd_read_bool(x['isTranspiledJS']) if 'isTranspiledJS' in x else _atd_missing_json_field('Environment', 'isTranspiledJS'),
                 projectHash=_atd_read_nullable(Sha256.from_json)(x['projectHash']) if 'projectHash' in x else _atd_missing_json_field('Environment', 'projectHash'),
                 configNamesHash=Sha256.from_json(x['configNamesHash']) if 'configNamesHash' in x else _atd_missing_json_field('Environment', 'configNamesHash'),
                 ci=_atd_read_nullable(_atd_read_string)(x['ci']) if 'ci' in x else _atd_missing_json_field('Environment', 'ci'),
@@ -977,7 +977,7 @@ class Environment:
         res: Dict[str, Any] = {}
         res['version'] = _atd_write_string(self.version)
         res['os'] = _atd_write_string(self.os)
-        res['isJS'] = _atd_write_bool(self.isJS)
+        res['isTranspiledJS'] = _atd_write_bool(self.isTranspiledJS)
         res['projectHash'] = _atd_write_nullable((lambda x: x.to_json()))(self.projectHash)
         res['configNamesHash'] = (lambda x: x.to_json())(self.configNamesHash)
         res['ci'] = _atd_write_nullable(_atd_write_string)(self.ci)

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -945,6 +945,8 @@ class Environment:
     """Original type: environment = { ... }"""
 
     version: str
+    os: str
+    isJS: bool
     projectHash: Optional[Sha256]
     configNamesHash: Sha256
     ci: Optional[str]
@@ -958,6 +960,8 @@ class Environment:
         if isinstance(x, dict):
             return cls(
                 version=_atd_read_string(x['version']) if 'version' in x else _atd_missing_json_field('Environment', 'version'),
+                os=_atd_read_string(x['os']) if 'os' in x else _atd_missing_json_field('Environment', 'os'),
+                isJS=_atd_read_bool(x['isJS']) if 'isJS' in x else _atd_missing_json_field('Environment', 'isJS'),
                 projectHash=_atd_read_nullable(Sha256.from_json)(x['projectHash']) if 'projectHash' in x else _atd_missing_json_field('Environment', 'projectHash'),
                 configNamesHash=Sha256.from_json(x['configNamesHash']) if 'configNamesHash' in x else _atd_missing_json_field('Environment', 'configNamesHash'),
                 ci=_atd_read_nullable(_atd_read_string)(x['ci']) if 'ci' in x else _atd_missing_json_field('Environment', 'ci'),
@@ -972,6 +976,8 @@ class Environment:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['version'] = _atd_write_string(self.version)
+        res['os'] = _atd_write_string(self.os)
+        res['isJS'] = _atd_write_bool(self.isJS)
         res['projectHash'] = _atd_write_nullable((lambda x: x.to_json()))(self.projectHash)
         res['configNamesHash'] = (lambda x: x.to_json())(self.configNamesHash)
         res['ci'] = _atd_write_nullable(_atd_write_string)(self.ci)


### PR DESCRIPTION
See: https://github.com/semgrep/semgrep/pull/9670

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
