### PR TITLE
Derive show and eq for some supply chain types

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -835,7 +835,7 @@ type dependency_match = {
  * classes can be hashed and put in sets (see calls to reachable_deps.add()
  * in semgrep SCA code)
  *)
-type ecosystem <python decorator="dataclass(frozen=True)"> = [
+type ecosystem <python decorator="dataclass(frozen=True)"> <ocaml attr="deriving show,eq"> = [
   | Npm <json name="npm">
   | Pypi  <json name="pypi">
   | Gem <json name="gem">
@@ -848,7 +848,7 @@ type ecosystem <python decorator="dataclass(frozen=True)"> = [
   | SwiftPM <json name="swiftpm">
 ]
 
-type transitivity <python decorator="dataclass(frozen=True)"> = [
+type transitivity <python decorator="dataclass(frozen=True)"> <ocaml attr="deriving show,eq"> = [
   | Direct <json name="direct">
   | Transitive <json name="transitive">
   | Unknown <json name="unknown">

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -116,7 +116,7 @@ type uuid = Semgrep_output_v1_t.uuid
 
 type uri = Semgrep_output_v1_t.uri
 
-type transitivity = Semgrep_output_v1_t.transitivity
+type transitivity = Semgrep_output_v1_t.transitivity [@@deriving show,eq]
 
 type todo = Semgrep_output_v1_t.todo
 
@@ -295,7 +295,7 @@ type scan_config = Semgrep_output_v1_t.scan_config = {
 
 type sca_parser_name = Semgrep_output_v1_t.sca_parser_name
 
-type ecosystem = Semgrep_output_v1_t.ecosystem
+type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show,eq]
 
 type dependency_child = Semgrep_output_v1_t.dependency_child = {
   package: string;

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -116,7 +116,7 @@ type uuid = Semgrep_output_v1_t.uuid
 
 type uri = Semgrep_output_v1_t.uri
 
-type transitivity = Semgrep_output_v1_t.transitivity
+type transitivity = Semgrep_output_v1_t.transitivity [@@deriving show,eq]
 
 type todo = Semgrep_output_v1_t.todo
 
@@ -295,7 +295,7 @@ type scan_config = Semgrep_output_v1_t.scan_config = {
 
 type sca_parser_name = Semgrep_output_v1_t.sca_parser_name
 
-type ecosystem = Semgrep_output_v1_t.ecosystem
+type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show,eq]
 
 type dependency_child = Semgrep_output_v1_t.dependency_child = {
   package: string;


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades

These types need `show` and `eq` instances for: https://github.com/semgrep/semgrep/pull/9695