### PR TITLE
feat(secrets): new origin policy for not community

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -177,7 +177,7 @@ type analysis_type <ocaml attr="deriving show"> = [
  *)
 type code_config  <ocaml attr="deriving show"> = { ?_rfu: int option; }
 
-type secrets_origin <ocaml attr="deriving show"> = [ Any | Semgrep ]
+type secrets_origin <ocaml attr="deriving show"> = [ Any | Semgrep | NoCommunity ]
 type secrets_config 
      <ocaml attr="deriving show"> = {
   permitted_origins: secrets_origin;

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -369,10 +369,27 @@ class Semgrep:
 
 
 @dataclass
+class NoCommunity:
+    """Original type: secrets_origin = [ ... | NoCommunity | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'NoCommunity'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'NoCommunity'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class SecretsOrigin:
     """Original type: secrets_origin = [ ... ]"""
 
-    value: Union[Any_, Semgrep]
+    value: Union[Any_, Semgrep, NoCommunity]
 
     @property
     def kind(self) -> str:
@@ -386,6 +403,8 @@ class SecretsOrigin:
                 return cls(Any_())
             if x == 'Semgrep':
                 return cls(Semgrep())
+            if x == 'NoCommunity':
+                return cls(NoCommunity())
             _atd_bad_json('SecretsOrigin', x)
         _atd_bad_json('SecretsOrigin', x)
 


### PR DESCRIPTION
This is needed since we are updating the way the origin based filtering for validation works, and changing it from a whitelist of [pro_rules] to a blacklist of [community], i.e., effectively, [pro_rules, custom, None].

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
