### PR TITLE
feat: add codeql

### DIFF
--- a/Language.ml
+++ b/Language.ml
@@ -30,6 +30,7 @@ type t =
 | Python2
 | Python3
 | Python
+| Ql
 | R
 | Ruby
 | Rust
@@ -443,6 +444,19 @@ let list = [
   reverse_exts = None;
   shebangs = [{|python|}; {|python2|}; {|python3|}];
   tags = [{|is_python|}];
+};
+{
+  id = Ql;
+  id_string = "ql";
+  name = "QL";
+  keys = [{|ql|}];
+  exts = [{|.ql|}; {|.qll|}];
+  maturity = Alpha;
+  example_ext = Some {|.ql|};
+  excluded_exts = [];
+  reverse_exts = None;
+  shebangs = [];
+  tags = [];
 };
 {
   id = R;

--- a/Language.mli
+++ b/Language.mli
@@ -30,6 +30,7 @@ type t =
 | Python2
 | Python3
 | Python
+| Ql
 | R
 | Ruby
 | Rust

--- a/generate.py
+++ b/generate.py
@@ -475,6 +475,15 @@ not ambiguous is welcome here.
     ),
     Language(
         comment="",
+        id_="ql",
+        name="QL",
+        keys=["ql"],
+        exts=[".ql", ".qll"],
+        example_ext=".ql",
+        maturity=Maturity.ALPHA,
+    ),
+    Language(
+        comment="",
         id_="r",
         name="R",
         keys=["r"],

--- a/lang.json
+++ b/lang.json
@@ -567,6 +567,24 @@
     ]
   },
   {
+    "id": "ql",
+    "name": "QL",
+    "keys": [
+      "ql"
+    ],
+    "maturity": "alpha",
+    "exts": [
+      ".ql",
+      ".qll"
+    ],
+    "example_ext": ".ql",
+    "excluded_exts": [],
+    "reverse_exts": null,
+    "shebangs": [],
+    "is_target_language": true,
+    "tags": []
+  },
+  {
     "id": "r",
     "name": "R",
     "keys": [


### PR DESCRIPTION
- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
