### PR TITLE
Adding a new metric for the number of scanned diff targets in inter-file diff scan mode

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -179,6 +179,11 @@ type pro_features = {
     (* The value is determined by the `--diff-depth` option, and it's utilized
        for inter-file differential scanning. Since semgrep 1.46 *)
     ?diffDepth <ocaml mutable>: int option;
+    (* The number of scanned files per language for inter-file diff scan mode.
+       This number represents the count of changed files and their limited
+       dependencies. Since semgrep 1.70 *)
+    ?numInterfileDiffScanned <ocaml mutable>: (string (* lang *) * int) list
+                                              <json repr="object"> option;
 }
 
 type analysis_type <ocaml attr="deriving show"> = [ 

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -487,12 +487,14 @@ class ProFeatures:
     """Original type: pro_features = { ... }"""
 
     diffDepth: Optional[int] = None
+    numInterfileDiffScanned: Optional[List[Tuple[str, int]]] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'ProFeatures':
         if isinstance(x, dict):
             return cls(
                 diffDepth=_atd_read_int(x['diffDepth']) if 'diffDepth' in x else None,
+                numInterfileDiffScanned=_atd_read_assoc_object_into_list(_atd_read_int)(x['numInterfileDiffScanned']) if 'numInterfileDiffScanned' in x else None,
             )
         else:
             _atd_bad_json('ProFeatures', x)
@@ -501,6 +503,8 @@ class ProFeatures:
         res: Dict[str, Any] = {}
         if self.diffDepth is not None:
             res['diffDepth'] = _atd_write_int(self.diffDepth)
+        if self.numInterfileDiffScanned is not None:
+            res['numInterfileDiffScanned'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.numInterfileDiffScanned)
         return res
 
     @classmethod


### PR DESCRIPTION

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
