### PR TITLE
feat: add nonkeyword_attributes_order_matters rule option in rule schema atd

### DIFF
--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -232,7 +232,7 @@ type fix_regex = {
  *)
 type rule_options = {
   ?constant_propagation: bool option;
-  ?decorators_in_order: bool option;
+  ?nonkeyword_attributes_order_matters: bool option;
   ?symbolic_propagation: bool option;
 
   ?taint_unify_mvars: bool option;

--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -232,6 +232,7 @@ type fix_regex = {
  *)
 type rule_options = {
   ?constant_propagation: bool option;
+  ?decorators_in_order: bool option;
   ?symbolic_propagation: bool option;
 
   ?taint_unify_mvars: bool option;

--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -232,7 +232,6 @@ type fix_regex = {
  *)
 type rule_options = {
   ?constant_propagation: bool option;
-  ?nonkeyword_attributes_order_matters: bool option;
   ?symbolic_propagation: bool option;
 
   ?taint_unify_mvars: bool option;
@@ -276,6 +275,8 @@ type rule_options = {
   ?generic_comment_style: generic_comment_style option;
 
   ?interfile: bool option;
+
+  ?nonkeyword_attributes_order_matters: bool option;
 }
 
 type generic_engine = [


### PR DESCRIPTION
This PR adds a new rule option `nonkeyword_attributes_order_matters`, which allows users to make decorator/ non-keyword attributes matching stricter, to the rule schema atd file. The default matching for attributes is order-agnostic, but if this rule option is set to `true`, non-keyword attributes (e.g. decorators in Python) will be matched in order, while keyword attributes (e.g. static, inline, etc) are not affected.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
