### PR TITLE
fix: update name of decorator rule option in rule schema atd

### DIFF
--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -276,7 +276,7 @@ type rule_options = {
 
   ?interfile: bool option;
 
-  ?nonkeyword_attributes_order_matters: bool option;
+  ?decorators_order_matters: bool option;
 }
 
 type generic_engine = [


### PR DESCRIPTION
This PR updates the name of the option added in #255. The team decided that `decorators_order_matters` is better than `nonkeyword_attributes_order_matters` after discussion as the new name is clearer to users.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
