### PR TITLE
feat: add support for move on aptos

### DIFF
--- a/Language.ml
+++ b/Language.ml
@@ -361,7 +361,7 @@ let list = [
 {
   id = Move_on_aptos;
   id_string = "move_on_aptos";
-  name = "Move (on Aptos)";
+  name = "Move on Aptos";
   keys = [{|move_on_aptos|}];
   exts = [{|.move|}];
   maturity = Develop;

--- a/Language.ml
+++ b/Language.ml
@@ -23,6 +23,7 @@ type t =
 | Kotlin
 | Lisp
 | Lua
+| Move_on_aptos
 | Ocaml
 | Php
 | Promql
@@ -352,6 +353,22 @@ let list = [
   excluded_exts = [];
   reverse_exts = None;
   shebangs = [{|lua|}];
+  tags = [];
+};
+(*
+  Move language with Aptos flavor
+*)
+{
+  id = Move_on_aptos;
+  id_string = "move_on_aptos";
+  name = "Move (on Aptos)";
+  keys = [{|move_on_aptos|}];
+  exts = [{|.move|}];
+  maturity = Develop;
+  example_ext = None;
+  excluded_exts = [];
+  reverse_exts = None;
+  shebangs = [];
   tags = [];
 };
 {

--- a/Language.mli
+++ b/Language.mli
@@ -23,6 +23,7 @@ type t =
 | Kotlin
 | Lisp
 | Lua
+| Move_on_aptos
 | Ocaml
 | Php
 | Promql

--- a/generate.py
+++ b/generate.py
@@ -402,6 +402,15 @@ not ambiguous is welcome here.
         shebangs=["lua"]
     ),
     Language(
+        comment="Move language with Aptos flavor",
+        id_="move_on_aptos",
+        name="Move (on Aptos)",
+        keys=["move_on_aptos"],
+        exts=[".move"],
+        maturity=Maturity.DEVELOP,
+        shebangs=[]
+    ),
+    Language(
         comment="",
         id_="ocaml",
         name="OCaml",

--- a/generate.py
+++ b/generate.py
@@ -404,7 +404,7 @@ not ambiguous is welcome here.
     Language(
         comment="Move language with Aptos flavor",
         id_="move_on_aptos",
-        name="Move (on Aptos)",
+        name="Move on Aptos",
         keys=["move_on_aptos"],
         exts=[".move"],
         maturity=Maturity.DEVELOP,

--- a/lang.json
+++ b/lang.json
@@ -418,6 +418,24 @@
     "tags": []
   },
   {
+    "comment": "Move language with Aptos flavor",
+    "id": "move_on_aptos",
+    "name": "Move (on Aptos)",
+    "keys": [
+      "move_on_aptos"
+    ],
+    "maturity": "develop",
+    "exts": [
+      ".move"
+    ],
+    "example_ext": null,
+    "excluded_exts": [],
+    "reverse_exts": null,
+    "shebangs": [],
+    "is_target_language": true,
+    "tags": []
+  },
+  {
     "id": "ocaml",
     "name": "OCaml",
     "keys": [

--- a/lang.json
+++ b/lang.json
@@ -420,7 +420,7 @@
   {
     "comment": "Move language with Aptos flavor",
     "id": "move_on_aptos",
-    "name": "Move (on Aptos)",
+    "name": "Move on Aptos",
     "keys": [
       "move_on_aptos"
     ],


### PR DESCRIPTION
Support for Move language on Aptos

---

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
