### PR TITLE
feat: add `when` to rule syntax

### DIFF
--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -352,6 +352,8 @@ type formula = {
 
   (* NEW: since 1.74 *)
   ?fix: string option;
+
+  ?when_: string option;
 }
 <json adapter.ocaml="Rule_schema_v2_adapter.Formula">
 


### PR DESCRIPTION
This PR adds `when` to the rule syntax.

- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
