### PR TITLE
fix: mark deployment id as mutable

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -102,7 +102,7 @@ type environment = {
     ~isDiffScan <python default="False"> <ocaml mutable> : bool;
     ?integrationName <ocaml mutable>: string option;
     ~isAuthenticated <python default="False"> <ocaml mutable>: bool;
-    ?deployment_id: int option;
+    ?deployment_id <ocaml mutable>: int option;
   }
 
 (*****************************************************************************)


### PR DESCRIPTION
I forgot to do this :/

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
