### PR TITLE
Add comments in semgrep_metrics.atd about clientIp and userAgent

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -13,15 +13,6 @@
  *   `pysemgrep`. Currently, we try to fit the tests and don't update the
  *   JSON output.
  * - specify the schema for the answer from https://metrics.semgrep.dev
- *   Here is an example of answer:
- *       { "errorType":"TypeError",
- *         "errorMessage":"Cannot read property 'map' of undefined",
- *          "trace":[
- *             "TypeError: Cannot read property 'map' of undefined",
- *             "    at createPerRuleObjects (/var/task/index.js:287:24)",
- *             "    at Runtime.exports.handler (/var/task/index.js:363:20)",
- *           ]
- *        }
 *)
 
 <python text="from dataclasses import field">
@@ -39,13 +30,21 @@ type datetime = string wrap <ocaml module="ATD_string_wrap.Datetime">
 
 type lang = string
 
-(* Note that there is no 'fpath' type here. We don't send concrete filenames *)
+(* Note that there is no 'fpath' type here. We don't send concrete filenames
+ * on purpose (see PRIVACY.md).
+ *)
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
-(* The use of 'mutable' below is a bit unusual, but many metrics fields are
+(* In addition to the fields below, some code in the semgrep-app-lambdas repo
+ * in metrics-handler/prod/index.js adds a few fields in the payload such as:
+ *
+ *    clientIP: string;
+ *    userAgent: string;
+ *  
+ * The use of 'mutable' below is a bit unusual, but many metrics fields are
  * adjusted in different modules and functions in Semgrep so it was simpler
  * to use a global in Metrics_.ml and mutable fields.
  * See the comments in Metrics_.ml about the global 'g' for more information.
@@ -53,26 +52,26 @@ type lang = string
 type payload = {
     (* required event and timing *)
     event_id <ocaml mutable>: uuid;
-    (* as stored in ~/.semgrep/settings.yml *)
-    anonymous_user_id <python default="''"> <ocaml mutable>: string;
     started_at <python default="Datetime('')"> <ocaml mutable>: datetime;
     sent_at <python default="Datetime('')"> <ocaml mutable>: datetime;
+    (* as stored in ~/.semgrep/settings.yml *)
+    anonymous_user_id <python default="''"> <ocaml mutable>: string;
 
-    (* other fields *)
+    (* The fields order below follows the presentation order in PRIVACY.md *)
     environment: environment;
     performance: performance;
-    extension: extension;
-    errors: errors;
-    (* TODO? why called value? *)
-    value: misc;
     (* the string is a 'lang' below but we can't use the alias because this
-     * confuses atd which is checking for a 'string' because of the json
+     * confuses ATD which is checking for a 'string' because of the JSON
      * repr annotation coming after.
      * TODO? should we move under performance instead of at the top here?
      *)
     ~parse_rate <ocaml mutable>: (string (* lang *) * parse_stat) list
                                  <json repr="object">;
+    errors: errors;
+    value: value;
 
+    (* not in PRIVACY.md *)
+    extension: extension;
     (* Metrics related to osemgrep migration. It's intentionally made optional
      * so that it's easier to remove the field without breaking backward
      * compatibility once the migration is complete.
@@ -85,10 +84,10 @@ type payload = {
 (*****************************************************************************)
 
 type environment = {
-    (* semgrep version *)
+    (* Semgrep CLI version (e.g., "1.45.0") *)
     version <ocaml mutable>: string;
     (* Since Semgrep 1.59 *)
-    os: string; (* e.g. linux *)
+    os: string; (* e.g. "linux" *)
     (* Since Semgrep 1.59 *)
     isTranspiledJS <ocaml mutable>: bool;
     projectHash <ocaml mutable>: sha256 nullable;
@@ -97,8 +96,10 @@ type environment = {
     (* TODO: should be just boolean *)
     ci <ocaml mutable>: string nullable;
     (* indicates whether `--baseline-commit` option has been specified. When
-       `baseline_commit` option is set, it implies that the scan is operating
-       in differential scan mode. Since semgrep 1.46 *)
+     * `baseline_commit` option is set, it implies that the scan is operating
+     * in differential scan mode.
+     * Since semgrep 1.46
+     *)
     ~isDiffScan <python default="False"> <ocaml mutable> : bool;
     ?integrationName <ocaml mutable>: string option;
     ~isAuthenticated <python default="False"> <ocaml mutable>: bool;
@@ -161,30 +162,54 @@ type errors = {
 type error = string
 
 (*****************************************************************************)
-(* Extension *)
+(* Value ("data that indicate how useful a run is for the end user") *)
 (*****************************************************************************)
 
-type extension = {
-    ?machineId <ocaml mutable>: string option;
-    ?isNewAppInstall <ocaml mutable>: bool option;
-    ?sessionId <ocaml mutable>: string option;
-    ?version <ocaml mutable>: string option;
-    ?ty <ocaml mutable>: string option;
-}
+type value = {
+    (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
+    features <ocaml mutable>: string list;
+    (* Since semgrep 1.46 *)
+    ?proFeatures <ocaml mutable>: pro_features option;
+    (* most important metric for the end user *)
+    ?numFindings <ocaml mutable>: int option;
+    (* Since Semgrep 1.56.0, see PA-3312 *)
+    ?numFindingsByProduct <ocaml mutable>: (string * int) list <json repr="object"> option;
+    ?numIgnored <ocaml mutable>: int option;
+    ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;
+    (* TODO: should be OSS | Pro, see semgrep_output_v1.atd engine_kind type *)
+    ~engineRequested <python default="'OSS'"> <ocaml mutable>: string;
+    (* Since Semgrep 1.54.0 *)
+    ?engineConfig <ocaml mutable>: engine_config option;
+    (* Since Semgrep 1.49.0 *)
+    ?interfileLanguagesUsed: string list option;
+  }
 
-(*****************************************************************************)
-(* Misc *)
-(*****************************************************************************)
 
 type pro_features = {
     (* The value is determined by the `--diff-depth` option, and it's utilized
-       for inter-file differential scanning. Since semgrep 1.46 *)
+     * for inter-file differential scanning.
+     * Since semgrep 1.46
+     *)
     ?diffDepth <ocaml mutable>: int option;
     (* The number of scanned files per language for inter-file diff scan mode.
-       This number represents the count of changed files and their limited
-       dependencies. Since semgrep 1.70 *)
+     * This number represents the count of changed files and their limited
+     * dependencies.
+     * Since semgrep 1.70
+     *)
     ?numInterfileDiffScanned <ocaml mutable>: (string (* lang *) * int) list
                                               <json repr="object"> option;
+}
+
+(* Since v1.55.0 *)
+type engine_config <ocaml attr="deriving show"> = {
+  analysis_type: analysis_type;
+  pro_langs: bool;
+  (* `Some c` where `c` is the config if the product was run.
+   * `None` if it was not run.
+   *)
+  ?code_config: code_config option;
+  ?secrets_config: secrets_config option;
+  ?supply_chain_config: supply_chain_config option;
 }
 
 type analysis_type <ocaml attr="deriving show"> = [ 
@@ -194,9 +219,9 @@ type analysis_type <ocaml attr="deriving show"> = [
 ]
 
 (* Ideally this and supply_chain_config would be unit or empty records,  but
- * atd doesn't generate correct code for python when unit is aliased
+ * ATD doesn't generate correct code for Python when unit is aliased
  * (to_json/from_json are wrong and try to call methods on a fake Unit class).
- * In the alternative, {} doesn't work either since atd just passes it through
+ * In the alternative, {} doesn't work either since ATD just passes it through
  * instead of converting to unit and it is not valid OCaml syntax.
  *
  * So we have a "reserved for future use" (RFU) field just to act as a
@@ -212,40 +237,28 @@ type secrets_config
 
 type supply_chain_config  <ocaml attr="deriving show"> = { ?_rfu: int option; }
 
-(* Since v1.55.0 *)
-type engine_config
-     <ocaml attr="deriving show"> = {
-  analysis_type: analysis_type;
-  pro_langs: bool;
-  (* `Some c` where `c` is the config if the product was run.
-   * `None` if it was not run.
-   *)
-  ?code_config: code_config option;
-  ?secrets_config: secrets_config option;
-  ?supply_chain_config: supply_chain_config option;
-}
+(*****************************************************************************)
+(* Extension *)
+(*****************************************************************************)
 
-type misc = {
-    (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
-    features <ocaml mutable>: string list;
-    (* Since semgrep 1.46 *)
-    ?proFeatures <ocaml mutable>: pro_features option;
-    ?numFindings <ocaml mutable>: int option;
-    (* Since Semgrep 1.56.0, see PA-3312 *)
-    ?numFindingsByProduct <ocaml mutable>: (string * int) list <json repr="object"> option;
-    ?numIgnored <ocaml mutable>: int option;
-    ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;
-    (* TODO: should be OSS | Pro, see semgrep_output_v1.atd engine_kind type *)
-    ~engineRequested <python default="'OSS'"> <ocaml mutable>: string;
-    (* Since Semgrep 1.54.0 *)
-    ?engineConfig <ocaml mutable>: engine_config option;
-    (* Since Semgrep 1.49.0 *)
-    ?interfileLanguagesUsed: string list option;
-  }
+(* Metrics from our IDE extensions? *)
+type extension = {
+    ?machineId <ocaml mutable>: string option;
+    ?isNewAppInstall <ocaml mutable>: bool option;
+    ?sessionId <ocaml mutable>: string option;
+    (* ?? *)
+    ?version <ocaml mutable>: string option;
+    (* ?? *)
+    ?ty <ocaml mutable>: string option;
+}
 
 (*****************************************************************************)
 (* Osemgrep specific metrics *)
 (*****************************************************************************)
+
+type osemgrep_metrics = {
+  ?format_output: osemgrep_format_output option;
+}
 
 type osemgrep_format_output = {
   (* Whether the RPC succeeded. *)
@@ -269,10 +282,16 @@ type osemgrep_format_output = {
   ?is_match: bool option;
 }
 
-type osemgrep_metrics = {
-  ?format_output: osemgrep_format_output option;
-}
-
 (*****************************************************************************)
 (* TODO Response by metrics.semgrep.dev *)
 (*****************************************************************************)
+(*   Here is an example of answer when an error occured:
+ *       { "errorType":"TypeError",
+ *         "errorMessage":"Cannot read property 'map' of undefined",
+ *          "trace":[
+ *             "TypeError: Cannot read property 'map' of undefined",
+ *             "    at createPerRuleObjects (/var/task/index.js:287:24)",
+ *             "    at Runtime.exports.handler (/var/task/index.js:363:20)",
+ *           ]
+ *        }
+ *)

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -264,27 +264,6 @@ from dataclasses import field
 
 
 @dataclass
-class Uuid:
-    """Original type: uuid"""
-
-    value: str
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'Uuid':
-        return cls(_atd_read_string(x))
-
-    def to_json(self) -> Any:
-        return _atd_write_string(self.value)
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'Uuid':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
 class SupplyChainConfig:
     """Original type: supply_chain_config = { ... }"""
 
@@ -307,27 +286,6 @@ class SupplyChainConfig:
 
     @classmethod
     def from_json_string(cls, x: str) -> 'SupplyChainConfig':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class Sha256:
-    """Original type: sha256"""
-
-    value: str
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'Sha256':
-        return cls(_atd_read_string(x))
-
-    def to_json(self) -> Any:
-        return _atd_write_string(self.value)
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'Sha256':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:
@@ -448,6 +406,297 @@ class SecretsConfig:
 
 
 @dataclass
+class ProFeatures:
+    """Original type: pro_features = { ... }"""
+
+    diffDepth: Optional[int] = None
+    numInterfileDiffScanned: Optional[List[Tuple[str, int]]] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'ProFeatures':
+        if isinstance(x, dict):
+            return cls(
+                diffDepth=_atd_read_int(x['diffDepth']) if 'diffDepth' in x else None,
+                numInterfileDiffScanned=_atd_read_assoc_object_into_list(_atd_read_int)(x['numInterfileDiffScanned']) if 'numInterfileDiffScanned' in x else None,
+            )
+        else:
+            _atd_bad_json('ProFeatures', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        if self.diffDepth is not None:
+            res['diffDepth'] = _atd_write_int(self.diffDepth)
+        if self.numInterfileDiffScanned is not None:
+            res['numInterfileDiffScanned'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.numInterfileDiffScanned)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'ProFeatures':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class CodeConfig:
+    """Original type: code_config = { ... }"""
+
+    _rfu: Optional[int] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'CodeConfig':
+        if isinstance(x, dict):
+            return cls(
+                _rfu=_atd_read_int(x['_rfu']) if '_rfu' in x else None,
+            )
+        else:
+            _atd_bad_json('CodeConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        if self._rfu is not None:
+            res['_rfu'] = _atd_write_int(self._rfu)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'CodeConfig':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Intraprocedural:
+    """Original type: analysis_type = [ ... | Intraprocedural | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Intraprocedural'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Intraprocedural'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Interprocedural:
+    """Original type: analysis_type = [ ... | Interprocedural | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Interprocedural'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Interprocedural'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Interfile:
+    """Original type: analysis_type = [ ... | Interfile | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Interfile'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Interfile'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class AnalysisType:
+    """Original type: analysis_type = [ ... ]"""
+
+    value: Union[Intraprocedural, Interprocedural, Interfile]
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return self.value.kind
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'AnalysisType':
+        if isinstance(x, str):
+            if x == 'Intraprocedural':
+                return cls(Intraprocedural())
+            if x == 'Interprocedural':
+                return cls(Interprocedural())
+            if x == 'Interfile':
+                return cls(Interfile())
+            _atd_bad_json('AnalysisType', x)
+        _atd_bad_json('AnalysisType', x)
+
+    def to_json(self) -> Any:
+        return self.value.to_json()
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'AnalysisType':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class EngineConfig:
+    """Original type: engine_config = { ... }"""
+
+    analysis_type: AnalysisType
+    pro_langs: bool
+    code_config: Optional[CodeConfig] = None
+    secrets_config: Optional[SecretsConfig] = None
+    supply_chain_config: Optional[SupplyChainConfig] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'EngineConfig':
+        if isinstance(x, dict):
+            return cls(
+                analysis_type=AnalysisType.from_json(x['analysis_type']) if 'analysis_type' in x else _atd_missing_json_field('EngineConfig', 'analysis_type'),
+                pro_langs=_atd_read_bool(x['pro_langs']) if 'pro_langs' in x else _atd_missing_json_field('EngineConfig', 'pro_langs'),
+                code_config=CodeConfig.from_json(x['code_config']) if 'code_config' in x else None,
+                secrets_config=SecretsConfig.from_json(x['secrets_config']) if 'secrets_config' in x else None,
+                supply_chain_config=SupplyChainConfig.from_json(x['supply_chain_config']) if 'supply_chain_config' in x else None,
+            )
+        else:
+            _atd_bad_json('EngineConfig', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['analysis_type'] = (lambda x: x.to_json())(self.analysis_type)
+        res['pro_langs'] = _atd_write_bool(self.pro_langs)
+        if self.code_config is not None:
+            res['code_config'] = (lambda x: x.to_json())(self.code_config)
+        if self.secrets_config is not None:
+            res['secrets_config'] = (lambda x: x.to_json())(self.secrets_config)
+        if self.supply_chain_config is not None:
+            res['supply_chain_config'] = (lambda x: x.to_json())(self.supply_chain_config)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'EngineConfig':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Value:
+    """Original type: value = { ... }"""
+
+    features: List[str]
+    proFeatures: Optional[ProFeatures] = None
+    numFindings: Optional[int] = None
+    numFindingsByProduct: Optional[List[Tuple[str, int]]] = None
+    numIgnored: Optional[int] = None
+    ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
+    engineRequested: str = field(default_factory=lambda: 'OSS')
+    engineConfig: Optional[EngineConfig] = None
+    interfileLanguagesUsed: Optional[List[str]] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Value':
+        if isinstance(x, dict):
+            return cls(
+                features=_atd_read_list(_atd_read_string)(x['features']) if 'features' in x else _atd_missing_json_field('Value', 'features'),
+                proFeatures=ProFeatures.from_json(x['proFeatures']) if 'proFeatures' in x else None,
+                numFindings=_atd_read_int(x['numFindings']) if 'numFindings' in x else None,
+                numFindingsByProduct=_atd_read_assoc_object_into_list(_atd_read_int)(x['numFindingsByProduct']) if 'numFindingsByProduct' in x else None,
+                numIgnored=_atd_read_int(x['numIgnored']) if 'numIgnored' in x else None,
+                ruleHashesWithFindings=_atd_read_assoc_object_into_list(_atd_read_int)(x['ruleHashesWithFindings']) if 'ruleHashesWithFindings' in x else None,
+                engineRequested=_atd_read_string(x['engineRequested']) if 'engineRequested' in x else 'OSS',
+                engineConfig=EngineConfig.from_json(x['engineConfig']) if 'engineConfig' in x else None,
+                interfileLanguagesUsed=_atd_read_list(_atd_read_string)(x['interfileLanguagesUsed']) if 'interfileLanguagesUsed' in x else None,
+            )
+        else:
+            _atd_bad_json('Value', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['features'] = _atd_write_list(_atd_write_string)(self.features)
+        if self.proFeatures is not None:
+            res['proFeatures'] = (lambda x: x.to_json())(self.proFeatures)
+        if self.numFindings is not None:
+            res['numFindings'] = _atd_write_int(self.numFindings)
+        if self.numFindingsByProduct is not None:
+            res['numFindingsByProduct'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.numFindingsByProduct)
+        if self.numIgnored is not None:
+            res['numIgnored'] = _atd_write_int(self.numIgnored)
+        if self.ruleHashesWithFindings is not None:
+            res['ruleHashesWithFindings'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.ruleHashesWithFindings)
+        res['engineRequested'] = _atd_write_string(self.engineRequested)
+        if self.engineConfig is not None:
+            res['engineConfig'] = (lambda x: x.to_json())(self.engineConfig)
+        if self.interfileLanguagesUsed is not None:
+            res['interfileLanguagesUsed'] = _atd_write_list(_atd_write_string)(self.interfileLanguagesUsed)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Value':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Uuid:
+    """Original type: uuid"""
+
+    value: str
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Uuid':
+        return cls(_atd_read_string(x))
+
+    def to_json(self) -> Any:
+        return _atd_write_string(self.value)
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Uuid':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Sha256:
+    """Original type: sha256"""
+
+    value: str
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Sha256':
+        return cls(_atd_read_string(x))
+
+    def to_json(self) -> Any:
+        return _atd_write_string(self.value)
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Sha256':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class RuleStats:
     """Original type: rule_stats = { ... }"""
 
@@ -476,39 +725,6 @@ class RuleStats:
 
     @classmethod
     def from_json_string(cls, x: str) -> 'RuleStats':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class ProFeatures:
-    """Original type: pro_features = { ... }"""
-
-    diffDepth: Optional[int] = None
-    numInterfileDiffScanned: Optional[List[Tuple[str, int]]] = None
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'ProFeatures':
-        if isinstance(x, dict):
-            return cls(
-                diffDepth=_atd_read_int(x['diffDepth']) if 'diffDepth' in x else None,
-                numInterfileDiffScanned=_atd_read_assoc_object_into_list(_atd_read_int)(x['numInterfileDiffScanned']) if 'numInterfileDiffScanned' in x else None,
-            )
-        else:
-            _atd_bad_json('ProFeatures', x)
-
-    def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        if self.diffDepth is not None:
-            res['diffDepth'] = _atd_write_int(self.diffDepth)
-        if self.numInterfileDiffScanned is not None:
-            res['numInterfileDiffScanned'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.numInterfileDiffScanned)
-        return res
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'ProFeatures':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:
@@ -731,222 +947,6 @@ class OsemgrepMetrics:
 
 
 @dataclass
-class CodeConfig:
-    """Original type: code_config = { ... }"""
-
-    _rfu: Optional[int] = None
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'CodeConfig':
-        if isinstance(x, dict):
-            return cls(
-                _rfu=_atd_read_int(x['_rfu']) if '_rfu' in x else None,
-            )
-        else:
-            _atd_bad_json('CodeConfig', x)
-
-    def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        if self._rfu is not None:
-            res['_rfu'] = _atd_write_int(self._rfu)
-        return res
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'CodeConfig':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class Intraprocedural:
-    """Original type: analysis_type = [ ... | Intraprocedural | ... ]"""
-
-    @property
-    def kind(self) -> str:
-        """Name of the class representing this variant."""
-        return 'Intraprocedural'
-
-    @staticmethod
-    def to_json() -> Any:
-        return 'Intraprocedural'
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class Interprocedural:
-    """Original type: analysis_type = [ ... | Interprocedural | ... ]"""
-
-    @property
-    def kind(self) -> str:
-        """Name of the class representing this variant."""
-        return 'Interprocedural'
-
-    @staticmethod
-    def to_json() -> Any:
-        return 'Interprocedural'
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class Interfile:
-    """Original type: analysis_type = [ ... | Interfile | ... ]"""
-
-    @property
-    def kind(self) -> str:
-        """Name of the class representing this variant."""
-        return 'Interfile'
-
-    @staticmethod
-    def to_json() -> Any:
-        return 'Interfile'
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class AnalysisType:
-    """Original type: analysis_type = [ ... ]"""
-
-    value: Union[Intraprocedural, Interprocedural, Interfile]
-
-    @property
-    def kind(self) -> str:
-        """Name of the class representing this variant."""
-        return self.value.kind
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'AnalysisType':
-        if isinstance(x, str):
-            if x == 'Intraprocedural':
-                return cls(Intraprocedural())
-            if x == 'Interprocedural':
-                return cls(Interprocedural())
-            if x == 'Interfile':
-                return cls(Interfile())
-            _atd_bad_json('AnalysisType', x)
-        _atd_bad_json('AnalysisType', x)
-
-    def to_json(self) -> Any:
-        return self.value.to_json()
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'AnalysisType':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class EngineConfig:
-    """Original type: engine_config = { ... }"""
-
-    analysis_type: AnalysisType
-    pro_langs: bool
-    code_config: Optional[CodeConfig] = None
-    secrets_config: Optional[SecretsConfig] = None
-    supply_chain_config: Optional[SupplyChainConfig] = None
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'EngineConfig':
-        if isinstance(x, dict):
-            return cls(
-                analysis_type=AnalysisType.from_json(x['analysis_type']) if 'analysis_type' in x else _atd_missing_json_field('EngineConfig', 'analysis_type'),
-                pro_langs=_atd_read_bool(x['pro_langs']) if 'pro_langs' in x else _atd_missing_json_field('EngineConfig', 'pro_langs'),
-                code_config=CodeConfig.from_json(x['code_config']) if 'code_config' in x else None,
-                secrets_config=SecretsConfig.from_json(x['secrets_config']) if 'secrets_config' in x else None,
-                supply_chain_config=SupplyChainConfig.from_json(x['supply_chain_config']) if 'supply_chain_config' in x else None,
-            )
-        else:
-            _atd_bad_json('EngineConfig', x)
-
-    def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        res['analysis_type'] = (lambda x: x.to_json())(self.analysis_type)
-        res['pro_langs'] = _atd_write_bool(self.pro_langs)
-        if self.code_config is not None:
-            res['code_config'] = (lambda x: x.to_json())(self.code_config)
-        if self.secrets_config is not None:
-            res['secrets_config'] = (lambda x: x.to_json())(self.secrets_config)
-        if self.supply_chain_config is not None:
-            res['supply_chain_config'] = (lambda x: x.to_json())(self.supply_chain_config)
-        return res
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'EngineConfig':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
-class Misc:
-    """Original type: misc = { ... }"""
-
-    features: List[str]
-    proFeatures: Optional[ProFeatures] = None
-    numFindings: Optional[int] = None
-    numFindingsByProduct: Optional[List[Tuple[str, int]]] = None
-    numIgnored: Optional[int] = None
-    ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
-    engineRequested: str = field(default_factory=lambda: 'OSS')
-    engineConfig: Optional[EngineConfig] = None
-    interfileLanguagesUsed: Optional[List[str]] = None
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'Misc':
-        if isinstance(x, dict):
-            return cls(
-                features=_atd_read_list(_atd_read_string)(x['features']) if 'features' in x else _atd_missing_json_field('Misc', 'features'),
-                proFeatures=ProFeatures.from_json(x['proFeatures']) if 'proFeatures' in x else None,
-                numFindings=_atd_read_int(x['numFindings']) if 'numFindings' in x else None,
-                numFindingsByProduct=_atd_read_assoc_object_into_list(_atd_read_int)(x['numFindingsByProduct']) if 'numFindingsByProduct' in x else None,
-                numIgnored=_atd_read_int(x['numIgnored']) if 'numIgnored' in x else None,
-                ruleHashesWithFindings=_atd_read_assoc_object_into_list(_atd_read_int)(x['ruleHashesWithFindings']) if 'ruleHashesWithFindings' in x else None,
-                engineRequested=_atd_read_string(x['engineRequested']) if 'engineRequested' in x else 'OSS',
-                engineConfig=EngineConfig.from_json(x['engineConfig']) if 'engineConfig' in x else None,
-                interfileLanguagesUsed=_atd_read_list(_atd_read_string)(x['interfileLanguagesUsed']) if 'interfileLanguagesUsed' in x else None,
-            )
-        else:
-            _atd_bad_json('Misc', x)
-
-    def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        res['features'] = _atd_write_list(_atd_write_string)(self.features)
-        if self.proFeatures is not None:
-            res['proFeatures'] = (lambda x: x.to_json())(self.proFeatures)
-        if self.numFindings is not None:
-            res['numFindings'] = _atd_write_int(self.numFindings)
-        if self.numFindingsByProduct is not None:
-            res['numFindingsByProduct'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.numFindingsByProduct)
-        if self.numIgnored is not None:
-            res['numIgnored'] = _atd_write_int(self.numIgnored)
-        if self.ruleHashesWithFindings is not None:
-            res['ruleHashesWithFindings'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.ruleHashesWithFindings)
-        res['engineRequested'] = _atd_write_string(self.engineRequested)
-        if self.engineConfig is not None:
-            res['engineConfig'] = (lambda x: x.to_json())(self.engineConfig)
-        if self.interfileLanguagesUsed is not None:
-            res['interfileLanguagesUsed'] = _atd_write_list(_atd_write_string)(self.interfileLanguagesUsed)
-        return res
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'Misc':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
 class Extension:
     """Original type: extension = { ... }"""
 
@@ -1132,14 +1132,14 @@ class Payload:
     """Original type: payload = { ... }"""
 
     event_id: Uuid
-    anonymous_user_id: str
     started_at: Datetime
     sent_at: Datetime
+    anonymous_user_id: str
     environment: Environment
     performance: Performance
-    extension: Extension
     errors: Errors
-    value: Misc
+    value: Value
+    extension: Extension
     parse_rate: List[Tuple[str, ParseStat]] = field(default_factory=lambda: [])
     osemgrep: Optional[OsemgrepMetrics] = None
 
@@ -1148,14 +1148,14 @@ class Payload:
         if isinstance(x, dict):
             return cls(
                 event_id=Uuid.from_json(x['event_id']) if 'event_id' in x else _atd_missing_json_field('Payload', 'event_id'),
-                anonymous_user_id=_atd_read_string(x['anonymous_user_id']) if 'anonymous_user_id' in x else _atd_missing_json_field('Payload', 'anonymous_user_id'),
                 started_at=Datetime.from_json(x['started_at']) if 'started_at' in x else _atd_missing_json_field('Payload', 'started_at'),
                 sent_at=Datetime.from_json(x['sent_at']) if 'sent_at' in x else _atd_missing_json_field('Payload', 'sent_at'),
+                anonymous_user_id=_atd_read_string(x['anonymous_user_id']) if 'anonymous_user_id' in x else _atd_missing_json_field('Payload', 'anonymous_user_id'),
                 environment=Environment.from_json(x['environment']) if 'environment' in x else _atd_missing_json_field('Payload', 'environment'),
                 performance=Performance.from_json(x['performance']) if 'performance' in x else _atd_missing_json_field('Payload', 'performance'),
-                extension=Extension.from_json(x['extension']) if 'extension' in x else _atd_missing_json_field('Payload', 'extension'),
                 errors=Errors.from_json(x['errors']) if 'errors' in x else _atd_missing_json_field('Payload', 'errors'),
-                value=Misc.from_json(x['value']) if 'value' in x else _atd_missing_json_field('Payload', 'value'),
+                value=Value.from_json(x['value']) if 'value' in x else _atd_missing_json_field('Payload', 'value'),
+                extension=Extension.from_json(x['extension']) if 'extension' in x else _atd_missing_json_field('Payload', 'extension'),
                 parse_rate=_atd_read_assoc_object_into_list(ParseStat.from_json)(x['parse_rate']) if 'parse_rate' in x else [],
                 osemgrep=OsemgrepMetrics.from_json(x['osemgrep']) if 'osemgrep' in x else None,
             )
@@ -1165,14 +1165,14 @@ class Payload:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['event_id'] = (lambda x: x.to_json())(self.event_id)
-        res['anonymous_user_id'] = _atd_write_string(self.anonymous_user_id)
         res['started_at'] = (lambda x: x.to_json())(self.started_at)
         res['sent_at'] = (lambda x: x.to_json())(self.sent_at)
+        res['anonymous_user_id'] = _atd_write_string(self.anonymous_user_id)
         res['environment'] = (lambda x: x.to_json())(self.environment)
         res['performance'] = (lambda x: x.to_json())(self.performance)
-        res['extension'] = (lambda x: x.to_json())(self.extension)
         res['errors'] = (lambda x: x.to_json())(self.errors)
         res['value'] = (lambda x: x.to_json())(self.value)
+        res['extension'] = (lambda x: x.to_json())(self.extension)
         res['parse_rate'] = _atd_write_assoc_list_to_object((lambda x: x.to_json()))(self.parse_rate)
         if self.osemgrep is not None:
             res['osemgrep'] = (lambda x: x.to_json())(self.osemgrep)


### PR DESCRIPTION
test plan:
make


- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades