### PR TITLE
feat: add new rule option for comparison to use cfg info

### DIFF
--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -277,6 +277,8 @@ type rule_options = {
   ?interfile: bool option;
 
   ?decorators_order_matters: bool option;
+
+  ?comparison_uses_control_flow: bool option;
 }
 
 type generic_engine = [


### PR DESCRIPTION
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
