### PR TITLE
add autofix and ignore fields

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -253,7 +253,7 @@ type extension = {
     ?version <ocaml mutable>: string option;
     (* type of extension, i.e. vscode, or intellij *)
     ?ty <ocaml mutable>: string option;
-    (* number of autofixes via code actions *)
+    (* number of autofixes accepted via code actions *)
     ?autofixCount <ocaml mutable>: int option;
     (* how many findings have been ignored *)
     ?ignoreCount <ocaml mutable>: int option;

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -243,13 +243,20 @@ type supply_chain_config  <ocaml attr="deriving show"> = { ?_rfu: int option; }
 
 (* Metrics from our IDE extensions? *)
 type extension = {
+    (* unique ID provided by the integration *)
     ?machineId <ocaml mutable>: string option;
+    (* if the integration was just installed *)
     ?isNewAppInstall <ocaml mutable>: bool option;
+    (* tracks unique sessions of the integration *)
     ?sessionId <ocaml mutable>: string option;
-    (* ?? *)
+    (* version of the integration. NOT semgrep version *)
     ?version <ocaml mutable>: string option;
-    (* ?? *)
+    (* type of extension, i.e. vscode, or intellij *)
     ?ty <ocaml mutable>: string option;
+    (* number of autofixes via code actions *)
+    ?autofixCount <ocaml mutable>: int option;
+    (* how many findings have been ignored *)
+    ?ignoreCount <ocaml mutable>: int option;
 }
 
 (*****************************************************************************)

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -955,6 +955,8 @@ class Extension:
     sessionId: Optional[str] = None
     version: Optional[str] = None
     ty: Optional[str] = None
+    autofixCount: Optional[int] = None
+    ignoreCount: Optional[int] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'Extension':
@@ -965,6 +967,8 @@ class Extension:
                 sessionId=_atd_read_string(x['sessionId']) if 'sessionId' in x else None,
                 version=_atd_read_string(x['version']) if 'version' in x else None,
                 ty=_atd_read_string(x['ty']) if 'ty' in x else None,
+                autofixCount=_atd_read_int(x['autofixCount']) if 'autofixCount' in x else None,
+                ignoreCount=_atd_read_int(x['ignoreCount']) if 'ignoreCount' in x else None,
             )
         else:
             _atd_bad_json('Extension', x)
@@ -981,6 +985,10 @@ class Extension:
             res['version'] = _atd_write_string(self.version)
         if self.ty is not None:
             res['ty'] = _atd_write_string(self.ty)
+        if self.autofixCount is not None:
+            res['autofixCount'] = _atd_write_int(self.autofixCount)
+        if self.ignoreCount is not None:
+            res['ignoreCount'] = _atd_write_int(self.ignoreCount)
         return res
 
     @classmethod


### PR DESCRIPTION
Record how many autofix and ignores have been triggered via IDE since users have asked for this

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
