### PR TITLE
feat: as-metavariable

### DIFF
--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -352,6 +352,9 @@ type formula = {
 
   (* NEW: since 1.74 *)
   ?fix: string option;
+
+  (* NEW: since 1.79 *)
+  ?as <ocaml name="as_">: string option;
 }
 <json adapter.ocaml="Rule_schema_v2_adapter.Formula">
 


### PR DESCRIPTION
This PR just adds the `as` field to formulae, due to the addition of embedding matches into arbitrary metavariables.
https://github.com/semgrep/semgrep-proprietary/pull/1730

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
