### PR TITLE
Circom language support

### DIFF
--- a/Language.ml
+++ b/Language.ml
@@ -6,6 +6,7 @@ type t =
 | Bash
 | C
 | Cairo
+| Circom
 | Clojure
 | Cpp
 | Csharp
@@ -122,6 +123,19 @@ let list = [
   keys = [{|cairo|}];
   exts = [{|.cairo|}];
   maturity = Alpha;
+  example_ext = None;
+  excluded_exts = [];
+  reverse_exts = None;
+  shebangs = [];
+  tags = [];
+};
+{
+  id = Circom;
+  id_string = "circom";
+  name = "Circom";
+  keys = [{|circom|}];
+  exts = [{|.circom|}];
+  maturity = Develop;
   example_ext = None;
   excluded_exts = [];
   reverse_exts = None;

--- a/Language.mli
+++ b/Language.mli
@@ -6,6 +6,7 @@ type t =
 | Bash
 | C
 | Cairo
+| Circom
 | Clojure
 | Cpp
 | Csharp

--- a/generate.py
+++ b/generate.py
@@ -234,6 +234,15 @@ LANGUAGES : List[Language] = [
     ),
     Language(
         comment="",
+        id_="circom",
+        name="Circom",
+        keys=["circom"],
+        exts=[".circom"],
+        maturity=Maturity.DEVELOP,
+        shebangs=[]
+    ),
+    Language(
+        comment="",
         id_="clojure",
         name="Clojure",
         keys=["clojure"],

--- a/lang.json
+++ b/lang.json
@@ -76,6 +76,23 @@
     "tags": []
   },
   {
+    "id": "circom",
+    "name": "Circom",
+    "keys": [
+      "circom"
+    ],
+    "maturity": "develop",
+    "exts": [
+      ".circom"
+    ],
+    "example_ext": null,
+    "excluded_exts": [],
+    "reverse_exts": null,
+    "shebangs": [],
+    "is_target_language": true,
+    "tags": []
+  },
+  {
     "id": "clojure",
     "name": "Clojure",
     "keys": [


### PR DESCRIPTION
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
