### PR TITLE
Add comments in semgrep_metrics.atd

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -28,6 +28,7 @@ type sha256 = string wrap <ocaml module="ATD_string_wrap.Sha256">
 (* RFC 3339 formatted datetime *)
 type datetime = string wrap <ocaml module="ATD_string_wrap.Datetime">
 
+(* ideally this would be the same than in Language.ml *)
 type lang = string
 
 (* Note that there is no 'fpath' type here. We don't send concrete filenames
@@ -41,11 +42,11 @@ type lang = string
 (* In addition to the fields below, some code in the semgrep-app-lambdas repo
  * in metrics-handler/prod/index.js adds a few fields in the payload such as:
  *
- *    clientIP: string;
- *    userAgent: string;
+ *    clientIP: string; (e.g., "1.2.3.4")
+ *    userAgent: string; (e.g., "Semgrep/1.37.0 (Docker) (command/ci)")
  *  
- * The use of 'mutable' below is a bit unusual, but many metrics fields are
- * adjusted in different modules and functions in Semgrep so it was simpler
+ * note: the use of 'mutable' below is a bit unusual, but many metrics fields
+ * are adjusted in different modules and functions in Semgrep so it was simpler
  * to use a global in Metrics_.ml and mutable fields.
  * See the comments in Metrics_.ml about the global 'g' for more information.
  *)
@@ -69,9 +70,8 @@ type payload = {
                                  <json repr="object">;
     errors: errors;
     value: value;
-
-    (* not in PRIVACY.md *)
     extension: extension;
+
     (* Metrics related to osemgrep migration. It's intentionally made optional
      * so that it's easier to remove the field without breaking backward
      * compatibility once the migration is complete.
@@ -166,7 +166,20 @@ type error = string
 (*****************************************************************************)
 
 type value = {
-    (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
+    (* The string has the form "key/value" and is used to encode lots
+     * of information such as:
+     *  - "subcommand/ci" (the subcommand is also part of the userAgent)
+     *  - "cli-flag/strict", "cli-flag/output"
+     *  - "cli-envvar/??"
+     *  - "cli-prompt/??"
+     *  - "config/local", "config/auto"
+     *  - "output/path", "output/url"
+     *  - "semgrepignore/exclude"
+     *  - "language/python", "language/<multilang"
+     *  - "registry-query/??"
+     *  - "ruleset/??"
+     * coupling: features is commented a lot in semgrep/PRIVACY.md
+    *)
     features <ocaml mutable>: string list;
     (* Since semgrep 1.46 *)
     ?proFeatures <ocaml mutable>: pro_features option;


### PR DESCRIPTION
test plan:
make


- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades