### PR TITLE
add semgrep-internal-metavariable-name to rule schema

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -289,6 +289,7 @@ $defs:
         - $ref: "#/$defs/metavariable-regex"
         - $ref: "#/$defs/metavariable-pattern"
         - $ref: "#/$defs/metavariable-type"
+        - $ref: "#/$defs/semgrep-internal-metavariable-name"
         - $ref: "#/$defs/metavariable-comparison"
         - $ref: "#/$defs/pattern-where-python"
   pattern-either-content:
@@ -614,6 +615,25 @@ $defs:
         additionalProperties: false
     required:
       - metavariable-type
+    additionalProperties: false
+  semgrep-internal-metavariable-name:
+    type: object
+    properties:
+      semgrep-internal-metavariable-name:
+        type: object
+        title: Filter for metavariables with a certain kind
+        properties:
+          metavariable:
+            type: string
+            title: Metavariable to match
+          kind:
+            title: Kind keyword
+            type: string
+        required:
+          - kind
+        additionalProperties: false
+    required:
+      - semgrep-internal-metavariable-name
     additionalProperties: false
   metavariable-comparison:
     type: object

--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -410,6 +410,8 @@ type metavariable_cond = {
   ?type_ <json name="type">: string option;
   ?types: string list option;
 
+  ?kind: string option;
+
   (* this covers regex:/pattern:, but also all:/any: with optional where:
    * CHECK: language is valid only when combined with a formula
    * CHECK: constant_propagation: is valid only when combined with regex:


### PR DESCRIPTION
closes CODE-7329

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
