### PR TITLE
update comment

### DIFF
--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -410,6 +410,8 @@ type metavariable_cond = {
   ?type_ <json name="type">: string option;
   ?types: string list option;
 
+  (* for semgrep-internal-metavariable-name, currently only support
+     "django-view" kind *)
   ?kind: string option;
 
   (* this covers regex:/pattern:, but also all:/any: with optional where:


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
