### PR TITLE
feat: add module as possible key

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -629,6 +629,9 @@ $defs:
           kind:
             title: Kind keyword
             type: string
+          module:
+            title: Kind keyword
+            type: string
         required:
           - kind
         additionalProperties: false

--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -413,6 +413,8 @@ type metavariable_cond = {
   (* for semgrep-internal-metavariable-name, currently only support
      "django-view" kind *)
   ?kind: string option;
+  (* for semgrep-internal-metavariable-name; consider renaming? for v2 *)
+  ?module: string option;
 
   (* this covers regex:/pattern:, but also all:/any: with optional where:
    * CHECK: language is valid only when combined with a formula


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
