### PR TITLE
chore: regenerate for #279

### DIFF
--- a/ast_generic_v1_j.ml
+++ b/ast_generic_v1_j.ml
@@ -1170,19 +1170,19 @@ let read_operator = (
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `Pipe
-            | "LDA" -> 
+            | "LDA" ->
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `LDA
-            | "RDA" -> 
+            | "RDA" ->
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `RDA
-            | "LSA" -> 
+            | "LSA" ->
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `LSA
-            | "RSA" -> 
+            | "RSA" ->
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `RSA
@@ -1279,6 +1279,8 @@ let read_operator = (
               `NotIs
             | "Background" ->
               `Background
+            | "Pipe" ->
+              `Pipe
             | "LDA" ->
               `LDA
             | "RDA" ->
@@ -1287,8 +1289,6 @@ let read_operator = (
               `LSA
             | "RSA" ->
               `RSA
-            | "Pipe" ->
-              `Pipe
             | x ->
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades

Looks like `make` wasn't run in https://github.com/semgrep/semgrep-interfaces/pull/279