### PR TITLE
fix: rename field for compatibility

### DIFF
--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -414,7 +414,7 @@ type metavariable_cond = {
      "django-view" kind *)
   ?kind: string option;
   (* for semgrep-internal-metavariable-name; consider renaming? for v2 *)
-  ?module: string option;
+  ?module_ <json name="module">: string option;
 
   (* this covers regex:/pattern:, but also all:/any: with optional where:
    * CHECK: language is valid only when combined with a formula


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
