### PR TITLE
fix: update required props for metavariable-name

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -633,7 +633,12 @@ $defs:
             title: Kind keyword
             type: string
         required:
-          - kind
+          - metavariable
+        anyOf:
+        - required:
+            - kind
+        - required:
+            - module
         additionalProperties: false
     required:
       - semgrep-internal-metavariable-name


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
