### PR TITLE
add install lines to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,15 @@ setup:
 	opam update
 	opam install --deps-only .
 
+setup-ALPINE:
+	apk add check-jsonschema
+
+setup-MACOS:
+	brew install check-jsonschema
+
+setup-PYTHON:
+	pip install check-jsonschema
+
 # The tests require semgrep-core, among other things.
 #
 .PHONY: test


### PR DESCRIPTION
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
