### PR TITLE
feat: also allow modules for metavariable-name

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -659,15 +659,23 @@ $defs:
             title: Kind keyword
             type: string
           module:
-            title: Kind keyword
+            title: A module name
             type: string
+          modules:
+            title: A list of module names
+            type: array
+            items:
+              type: string
         required:
           - metavariable
         anyOf:
         - required:
             - kind
-        - required:
-            - module
+        - oneOf:
+          - required:
+              - module
+          - required:
+              - modules
         additionalProperties: false
     required:
       - semgrep-internal-metavariable-name

--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -415,6 +415,7 @@ type metavariable_cond = {
   ?kind: string option;
   (* for semgrep-internal-metavariable-name; consider renaming? for v2 *)
   ?module_ <json name="module">: string option;
+  ?modules: string list option;
 
   (* this covers regex:/pattern:, but also all:/any: with optional where:
    * CHECK: language is valid only when combined with a formula


### PR DESCRIPTION
Similar to `type` and `types`, extends the existing support for `module` to also allow for `modules`.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
