### PR TITLE
Adding Move on Sui to languages

### DIFF
--- a/Language.ml
+++ b/Language.ml
@@ -24,6 +24,7 @@ type t =
 | Kotlin
 | Lisp
 | Lua
+| Move_on_sui
 | Move_on_aptos
 | Ocaml
 | Php
@@ -367,6 +368,22 @@ let list = [
   excluded_exts = [];
   reverse_exts = None;
   shebangs = [{|lua|}];
+  tags = [];
+};
+(*
+  Move language with SUI flavor
+*)
+{
+  id = Move_on_sui;
+  id_string = "move_on_sui";
+  name = "Move on Sui";
+  keys = [{|move_on_sui|}];
+  exts = [{|.move|}];
+  maturity = Develop;
+  example_ext = None;
+  excluded_exts = [];
+  reverse_exts = None;
+  shebangs = [];
   tags = [];
 };
 (*

--- a/Language.mli
+++ b/Language.mli
@@ -24,6 +24,7 @@ type t =
 | Kotlin
 | Lisp
 | Lua
+| Move_on_sui
 | Move_on_aptos
 | Ocaml
 | Php

--- a/generate.py
+++ b/generate.py
@@ -411,6 +411,15 @@ not ambiguous is welcome here.
         shebangs=["lua"]
     ),
     Language(
+        comment="Move language with SUI flavor",
+        id_="move_on_sui" ,
+        name="Move on Sui",
+        keys=["move_on_sui"],
+        exts=[".move"],
+        maturity=Maturity.DEVELOP,
+        shebangs=[]
+    ),
+    Language(
         comment="Move language with Aptos flavor",
         id_="move_on_aptos",
         name="Move on Aptos",

--- a/lang.json
+++ b/lang.json
@@ -435,6 +435,24 @@
     "tags": []
   },
   {
+    "comment": "Move language with SUI flavor",
+    "id": "move_on_sui",
+    "name": "Move on Sui",
+    "keys": [
+      "move_on_sui"
+    ],
+    "maturity": "develop",
+    "exts": [
+      ".move"
+    ],
+    "example_ext": null,
+    "excluded_exts": [],
+    "reverse_exts": null,
+    "shebangs": [],
+    "is_target_language": true,
+    "tags": []
+  },
+  {
     "comment": "Move language with Aptos flavor",
     "id": "move_on_aptos",
     "name": "Move on Aptos",


### PR DESCRIPTION
- [X ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades 
      I assume that adding a new language is backwards compatiable?
