### PR TITLE
Remove some useless deriving yojson

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -1932,7 +1932,7 @@ type lockfile_kind
 ] <ocaml repr="classic">
 
 type manifest_kind 
-  <ocaml attr="deriving show, eq, yojson">
+  <ocaml attr="deriving show, eq">
   <python decorator="dataclass(frozen=True)">   = [
   | RequirementsIn
     (* A Pip Requirements.in in file, which follows the format of requirements.txt - https://pip.pypa.io/en/stable/reference/requirements-file-format/ *)

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -229,8 +229,7 @@ type tag = Semgrep_output_v1_t.tag
 type resolution_method = Semgrep_output_v1_t.resolution_method
   [@@deriving show]
 
-type manifest_kind = Semgrep_output_v1_t.manifest_kind
-  [@@deriving show, eq, yojson]
+type manifest_kind = Semgrep_output_v1_t.manifest_kind [@@deriving show, eq]
 
 type lockfile_kind = Semgrep_output_v1_t.lockfile_kind = 
     PipRequirementsTxt | PoetryLock | PipfileLock | UvLock

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -229,8 +229,7 @@ type tag = Semgrep_output_v1_t.tag
 type resolution_method = Semgrep_output_v1_t.resolution_method
   [@@deriving show]
 
-type manifest_kind = Semgrep_output_v1_t.manifest_kind
-  [@@deriving show, eq, yojson]
+type manifest_kind = Semgrep_output_v1_t.manifest_kind [@@deriving show, eq]
 
 type lockfile_kind = Semgrep_output_v1_t.lockfile_kind = 
     PipRequirementsTxt | PoetryLock | PipfileLock | UvLock


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades