### PR TITLE
fix: erroneous comment in interface

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -2339,7 +2339,7 @@ type function_return <python decorator="dataclass(frozen=True)"> = [
   | RetSarifFormat of string
   | RetValidate of bool
   | RetResolveDependencies of (dependency_source * resolution_result) list
-  | RetUploadSymbolAnalysis of (* error msg *) string
+  | RetUploadSymbolAnalysis of (* success msg *) string
   | RetDumpRulePartitions of bool
   | RetTransitiveReachabilityFilter of transitive_finding list
 ]


### PR DESCRIPTION
Just fixed a typo, the return value is not an error message, it only returns in the success case. It's a success message.