### PR TITLE
feat: expose metavariable-name.modules

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -323,6 +323,7 @@ $defs:
         - $ref: "#/$defs/metavariable-regex"
         - $ref: "#/$defs/metavariable-pattern"
         - $ref: "#/$defs/metavariable-type"
+        - $ref: "#/$defs/semgrep-internal-metavariable-name"
         - $ref: "#/$defs/metavariable-name"
         - $ref: "#/$defs/metavariable-comparison"
         - $ref: "#/$defs/pattern-where-python"
@@ -669,14 +670,19 @@ $defs:
               type: string
         required:
           - metavariable
-        anyOf:
-        - oneOf:
-          - required:
-              - module
-          - required:
-              - modules
+        oneOf:
+        - required:
+            - module
+        - required:
+            - modules
         additionalProperties: false
-      # EXPERIMENTAL variant
+    required:
+      - metavariable-name
+    additionalProperties: false
+  # EXPERIMENTAL variant
+  semgrep-internal-metavariable-name:
+    type: object
+    properties:
       semgrep-internal-metavariable-name:
         type: object
         title: Filter for metavariables with a certain kind
@@ -708,11 +714,8 @@ $defs:
           - required:
               - modules
         additionalProperties: false
-    oneOf:
-    - required:
-        - metavariable-name
-    - required:
-        - semgrep-internal-metavariable-name
+    required:
+      - semgrep-internal-metavariable-name
     additionalProperties: false
   metavariable-comparison:
     type: object

--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -323,7 +323,7 @@ $defs:
         - $ref: "#/$defs/metavariable-regex"
         - $ref: "#/$defs/metavariable-pattern"
         - $ref: "#/$defs/metavariable-type"
-        - $ref: "#/$defs/semgrep-internal-metavariable-name"
+        - $ref: "#/$defs/metavariable-name"
         - $ref: "#/$defs/metavariable-comparison"
         - $ref: "#/$defs/pattern-where-python"
   pattern-either-content:
@@ -647,9 +647,36 @@ $defs:
     required:
       - metavariable-type
     additionalProperties: false
-  semgrep-internal-metavariable-name:
+  metavariable-name:
     type: object
     properties:
+      # NOTE: Similar to the semgrep-internal-* variant, but doesn't yet permit
+      # a `kind` constraint.
+      metavariable-name:
+        type: object
+        title: Filter for metavariables with a certain kind
+        properties:
+          metavariable:
+            type: string
+            title: Metavariable to match
+          module:
+            title: A module name
+            type: string
+          modules:
+            title: A list of module names
+            type: array
+            items:
+              type: string
+        required:
+          - metavariable
+        anyOf:
+        - oneOf:
+          - required:
+              - module
+          - required:
+              - modules
+        additionalProperties: false
+      # EXPERIMENTAL variant
       semgrep-internal-metavariable-name:
         type: object
         title: Filter for metavariables with a certain kind
@@ -657,6 +684,8 @@ $defs:
           metavariable:
             type: string
             title: Metavariable to match
+          # If updating kind, consider if this experimental version can be
+          # removed in favour of the non-prefixed one.
           kind:
             title: Kind keyword
             type: string
@@ -679,8 +708,11 @@ $defs:
           - required:
               - modules
         additionalProperties: false
-    required:
-      - semgrep-internal-metavariable-name
+    oneOf:
+    - required:
+        - metavariable-name
+    - required:
+        - semgrep-internal-metavariable-name
     additionalProperties: false
   metavariable-comparison:
     type: object

--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -413,7 +413,7 @@ type metavariable_cond = {
   (* for semgrep-internal-metavariable-name, currently only support
      "django-view" kind *)
   ?kind: string option;
-  (* for semgrep-internal-metavariable-name; consider renaming? for v2 *)
+  (* for metavariable-name; consider renaming? for v2 *)
   ?module_ <json name="module">: string option;
   ?modules: string list option;
 


### PR DESCRIPTION
Allows metavariable-name to appear without a semgrep-internal prefix when using the modules constraint (but not yet for kind).

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
