### PR TITLE
rule_schema_v1: taint: Add multi-requires

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -139,7 +139,15 @@ $defs:
     $ref: "#/$defs/new-pattern"
     properties:
       requires:
-        type: string
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: object
+              minProperties: 1
+              maxProperties: 1
+              additionalProperties:
+                type: string
   new-sanitizer-pattern:
     $ref: "#/$defs/new-pattern"
     properties:


### PR DESCRIPTION
    pattern-sinks:
    - patterns:
      - pattern: $OBJ.foo($SINK, $ARG1)
      - focus-metavariable: $SINK
      requires:
      - $SINK: TAINT
      - $OBJ: OBJ
      - $ARG1: ARG1

Required-by: semgrep/semgrep-proprietary#3414

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
