### PR TITLE
feat(sca): Add deriving show, eq to tr_cache_key

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -1862,7 +1862,7 @@ type scan_config = {
  * cached entries (e.g., the semgrep engine itself changed enough that
  * some past cached results might be wrong and should be recomputed)
 *)
-type tr_cache_key = {
+type tr_cache_key <ocaml attr="deriving show, eq"> = {
     rule_id: rule_id;
     (* this can be the checksum of the content of the rule (JSON or YAML form) *)
     rule_version: string;

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -398,6 +398,7 @@ type tr_cache_key = Semgrep_output_v1_t.tr_cache_key = {
   package_url: string;
   extra: string
 }
+  [@@deriving show, eq]
 
 type tr_query_cache_response = Semgrep_output_v1_t.tr_query_cache_response = {
   cached: (tr_cache_key * tr_cache_match_result) list

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -398,6 +398,7 @@ type tr_cache_key = Semgrep_output_v1_t.tr_cache_key = {
   package_url: string;
   extra: string
 }
+  [@@deriving show, eq]
 
 type tr_query_cache_response = Semgrep_output_v1_t.tr_query_cache_response = {
   cached: (tr_cache_key * tr_cache_match_result) list


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
