### PR TITLE
add deriving eq to rule_id

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -142,7 +142,7 @@ type location
 
 (* e.g., "javascript.security.do-not-use-eval" *)
 type rule_id
-     <ocaml attr="deriving show">
+     <ocaml attr="deriving show, eq">
      <python decorator="dataclass(frozen=True)"> =
   string wrap <ocaml module="Rule_ID">
 

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -117,7 +117,7 @@ type engine_of_finding = Semgrep_output_v1_t.engine_of_finding
 
 type raw_json = Yojson.Basic.t
 
-type rule_id = Semgrep_output_v1_t.rule_id [@@deriving show]
+type rule_id = Semgrep_output_v1_t.rule_id [@@deriving show, eq]
 
 type sca_pattern = Semgrep_output_v1_t.sca_pattern = {
   ecosystem: ecosystem;

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -117,7 +117,7 @@ type engine_of_finding = Semgrep_output_v1_t.engine_of_finding
 
 type raw_json = Yojson.Basic.t
 
-type rule_id = Semgrep_output_v1_t.rule_id [@@deriving show]
+type rule_id = Semgrep_output_v1_t.rule_id [@@deriving show, eq]
 
 type sca_pattern = Semgrep_output_v1_t.sca_pattern = {
   ecosystem: ecosystem;


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
