### PR TITLE
Update some language extensions based on existing test files

### DIFF
--- a/lang.json
+++ b/lang.json
@@ -151,7 +151,8 @@
     ],
     "maturity": "ga",
     "exts": [
-      ".cs"
+      ".cs",
+      ".cshtml"
     ],
     "example_ext": null,
     "excluded_exts": [],
@@ -285,7 +286,8 @@
     ],
     "maturity": "ga",
     "exts": [
-      ".java"
+      ".java",
+      ".jsp"
     ],
     "example_ext": null,
     "excluded_exts": [],
@@ -304,9 +306,12 @@
     "maturity": "ga",
     "exts": [
       ".cjs",
+      ".ejs",
       ".js",
       ".jsx",
-      ".mjs"
+      ".mjs",
+      ".mustache",
+      ".pug"
     ],
     "example_ext": ".jsx",
     "excluded_exts": [
@@ -663,6 +668,7 @@
     ],
     "maturity": "ga",
     "exts": [
+      ".erb",
       ".rb"
     ],
     "example_ext": null,
@@ -701,7 +707,8 @@
     ],
     "maturity": "ga",
     "exts": [
-      ".scala"
+      ".scala",
+      ".sbt"
     ],
     "example_ext": null,
     "excluded_exts": [],


### PR DESCRIPTION
### Changes

I observed some test cases from https://github.com/semgrep/semgrep-rules that were not being tagged with a language while being loaded because they did not have their extensions listed here.

I added the extensions I observed for the languages they belong to. I'm mostly tracking the impact this will have on the registry loading & running tests, but if there are severe other implications of this change I can retract it.

### Testing
I did not edit a `.atd` file, so I did not run make.
 
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!

