### PR TITLE
add `fqn` and `fqns` to rule schema

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -711,6 +711,14 @@ $defs:
             type: array
             items:
               type: string
+          fqn:
+            title: A fully qualified name
+            type: string
+          fqns:
+            title: A list of fully qualified names
+            type: array
+            items:
+              type: string
         required:
           - metavariable
         anyOf:
@@ -721,6 +729,11 @@ $defs:
               - module
           - required:
               - modules
+        - oneOf:
+          - required:
+              - fqn
+          - required:
+              - fqns
         additionalProperties: false
     required:
       - semgrep-internal-metavariable-name

--- a/rule_schema_v2.atd
+++ b/rule_schema_v2.atd
@@ -413,6 +413,11 @@ type metavariable_cond = {
   (* for semgrep-internal-metavariable-name, currently only support
      "django-view" kind *)
   ?kind: string option;
+
+  (* for semgrep-internal-metavariable-name *)
+  ?fqn: string option;
+  ?fqns: string list option;
+
   (* for metavariable-name; consider renaming? for v2 *)
   ?module_ <json name="module">: string option;
   ?modules: string list option;


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
