### PR TITLE
chore: add checkbox for pro PR to PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,4 @@
       See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
 	  Note that the types related to the semgrep-core JSON output or the
 	  semgrep-core RPC do not need to be backward compatible!
+- [ ] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged


### PR DESCRIPTION
Adds another checkbox to remind people to ensure that their accompanying semgrep-pro PRs are ready to merge before merging the semgrep-interfaces PR. This will hopefully help avoid situations where later changes to semgrep-interfaces cannot be used in semgrep-pro.

- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
