### PR TITLE
feat: add metrics for mcp rpc calls to semgrep

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -270,7 +270,6 @@ type extension = {
 }
 
 type mcp = {
-    ?deployment_id <ocaml mutable>: int option;
     ?session_id <ocaml mutable>: string option;
     ?num_findings <ocaml mutable>: int option;
 }

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -270,7 +270,10 @@ type extension = {
 }
 
 type mcp = {
-    ?test <ocaml mutable>: string option;
+    ?deployment_id <ocaml mutable>: int option;
+    ?session_id <ocaml mutable>: string option;
+    ?num_findings <ocaml mutable>: int option;
+    ?num_rules <ocaml mutable>: int option;
 }
 
 (*****************************************************************************)

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -73,6 +73,7 @@ type payload = {
     errors: errors;
     value: value;
     extension: extension;
+    mcp: mcp;
 }
 
 (*****************************************************************************)
@@ -266,6 +267,10 @@ type extension = {
     ?autofixCount <ocaml mutable>: int option;
     (* how many findings have been ignored *)
     ?ignoreCount <ocaml mutable>: int option;
+}
+
+type mcp = {
+    ?test <ocaml mutable>: string option;
 }
 
 (*****************************************************************************)

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -273,7 +273,6 @@ type mcp = {
     ?deployment_id <ocaml mutable>: int option;
     ?session_id <ocaml mutable>: string option;
     ?num_findings <ocaml mutable>: int option;
-    ?num_rules <ocaml mutable>: int option;
 }
 
 (*****************************************************************************)

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -868,7 +868,6 @@ class ParseStat:
 class Mcp:
     """Original type: mcp = { ... }"""
 
-    deployment_id: Optional[int] = None
     session_id: Optional[str] = None
     num_findings: Optional[int] = None
 
@@ -876,7 +875,6 @@ class Mcp:
     def from_json(cls, x: Any) -> 'Mcp':
         if isinstance(x, dict):
             return cls(
-                deployment_id=_atd_read_int(x['deployment_id']) if 'deployment_id' in x else None,
                 session_id=_atd_read_string(x['session_id']) if 'session_id' in x else None,
                 num_findings=_atd_read_int(x['num_findings']) if 'num_findings' in x else None,
             )
@@ -885,8 +883,6 @@ class Mcp:
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
-        if self.deployment_id is not None:
-            res['deployment_id'] = _atd_write_int(self.deployment_id)
         if self.session_id is not None:
             res['session_id'] = _atd_write_string(self.session_id)
         if self.num_findings is not None:

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -865,6 +865,43 @@ class ParseStat:
 
 
 @dataclass
+class Mcp:
+    """Original type: mcp = { ... }"""
+
+    deployment_id: Optional[int] = None
+    session_id: Optional[str] = None
+    num_findings: Optional[int] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Mcp':
+        if isinstance(x, dict):
+            return cls(
+                deployment_id=_atd_read_int(x['deployment_id']) if 'deployment_id' in x else None,
+                session_id=_atd_read_string(x['session_id']) if 'session_id' in x else None,
+                num_findings=_atd_read_int(x['num_findings']) if 'num_findings' in x else None,
+            )
+        else:
+            _atd_bad_json('Mcp', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        if self.deployment_id is not None:
+            res['deployment_id'] = _atd_write_int(self.deployment_id)
+        if self.session_id is not None:
+            res['session_id'] = _atd_write_string(self.session_id)
+        if self.num_findings is not None:
+            res['num_findings'] = _atd_write_int(self.num_findings)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Mcp':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class Extension:
     """Original type: extension = { ... }"""
 
@@ -1066,6 +1103,7 @@ class Payload:
     errors: Errors
     value: Value
     extension: Extension
+    mcp: Mcp
     parse_rate: List[Tuple[str, ParseStat]] = field(default_factory=lambda: [])
 
     @classmethod
@@ -1081,6 +1119,7 @@ class Payload:
                 errors=Errors.from_json(x['errors']) if 'errors' in x else _atd_missing_json_field('Payload', 'errors'),
                 value=Value.from_json(x['value']) if 'value' in x else _atd_missing_json_field('Payload', 'value'),
                 extension=Extension.from_json(x['extension']) if 'extension' in x else _atd_missing_json_field('Payload', 'extension'),
+                mcp=Mcp.from_json(x['mcp']) if 'mcp' in x else _atd_missing_json_field('Payload', 'mcp'),
                 parse_rate=_atd_read_assoc_object_into_list(ParseStat.from_json)(x['parse_rate']) if 'parse_rate' in x else [],
             )
         else:
@@ -1097,6 +1136,7 @@ class Payload:
         res['errors'] = (lambda x: x.to_json())(self.errors)
         res['value'] = (lambda x: x.to_json())(self.value)
         res['extension'] = (lambda x: x.to_json())(self.extension)
+        res['mcp'] = (lambda x: x.to_json())(self.mcp)
         res['parse_rate'] = _atd_write_assoc_list_to_object((lambda x: x.to_json()))(self.parse_rate)
         return res
 


### PR DESCRIPTION
- [x] I ran `make setup && make`to update the generated code after editing a `.atd`file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
For example, the Semgrep backend need to still be able to _consume_data
generated by Semgrep 1.50.0.
See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
Note that the types related to the semgrep-core JSON output or the
semgrep-core RPC do not need to be backward compatible!
- [x] Any accompanying changes in `semgrep-proprietary`are approved and ready to merge once this PR is merged