### PR TITLE
nit(cli): update comment

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -1604,7 +1604,7 @@ type scan_metadata = {
   cli_version: version;
   unique_id: uuid; (* client generated uuid for the scan *)
   requested_products: product list;
-  (* since 1.132.0 *)
+  (* since 1.133.0 *)
   ~compress_config: bool;
   (* since 1.47.0 *)
   ~dry_run: bool;


### PR DESCRIPTION
Off by one on the comment.


- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
- [ ] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged
