### PR TITLE
chore(sca): make dependency types use frozen dataclasses"

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -683,7 +683,8 @@ type sca_pattern <ocaml attr="deriving ord"> = {
 }
 
 (* alt: sca_dependency? *)
-type found_dependency <ocaml attr="deriving ord"> = {
+type found_dependency <ocaml attr="deriving ord">
+    <python decorator="dataclass(frozen=True)"> = {
   package: string;
   version: string;
   ecosystem: ecosystem;
@@ -2651,7 +2652,9 @@ type resolved_subproject
    errors: sca_error list;
 }
 
-type resolved_dependency = (found_dependency * downloaded_dependency option)
+type resolved_dependency 
+    <python decorator="dataclass(frozen=True)"> =
+(found_dependency * downloaded_dependency option)
 
 (* Information about a 3rd-party lib downloaded for Transitive Reachability.
  * To accompany a found_dependency within the Semgrep CLI, passed back and forth 

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -712,7 +712,7 @@ class Fpath:
         return json.dumps(self.to_json(), **kw)
 
 
-@dataclass
+@dataclass(frozen=True)
 class FoundDependency:
     """Original type: found_dependency = { ... }"""
 
@@ -5036,7 +5036,7 @@ class DownloadedDependency:
         return json.dumps(self.to_json(), **kw)
 
 
-@dataclass
+@dataclass(frozen=True)
 class ResolvedDependency:
     """Original type: resolved_dependency"""
 


### PR DESCRIPTION
Updates the types for dependency resolution results to use frozen dataclasses.
This allows us to create sets from them, making it easier to compare in tests.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
- [x] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged
