### PR TITLE
feat: add Gosu language with develop maturity

### DIFF
--- a/Language.ml
+++ b/Language.ml
@@ -14,6 +14,7 @@ type t =
 | Dockerfile
 | Elixir
 | Go
+| Gosu
 | Hack
 | Html
 | Java
@@ -239,6 +240,19 @@ let list = [
   reverse_exts = None;
   shebangs = [];
   tags = [];
+};
+{
+  id = Gosu;
+  id_string = "gosu";
+  name = "Gosu";
+  keys = [{|gosu|}];
+  exts = [{|.gs|}];
+  maturity = Develop;
+  example_ext = None;
+  excluded_exts = [];
+  reverse_exts = None;
+  shebangs = [];
+  tags = [{|is_proprietary|}];
 };
 {
   id = Hack;

--- a/Language.mli
+++ b/Language.mli
@@ -14,6 +14,7 @@ type t =
 | Dockerfile
 | Elixir
 | Go
+| Gosu
 | Hack
 | Html
 | Java

--- a/generate.py
+++ b/generate.py
@@ -316,6 +316,16 @@ not ambiguous is welcome here.
     ),
     Language(
         comment="",
+        id_="gosu",
+        name="Gosu",
+        keys=["gosu"],
+        exts=[".gs"],
+        maturity=Maturity.DEVELOP,
+        shebangs=[],
+        tags=["is_proprietary"],
+    ),
+    Language(
+        comment="",
         id_="hack",
         name="Hack",
         keys=["hack"],

--- a/lang.json
+++ b/lang.json
@@ -239,6 +239,25 @@
     "tags": []
   },
   {
+    "id": "gosu",
+    "name": "Gosu",
+    "keys": [
+      "gosu"
+    ],
+    "maturity": "develop",
+    "exts": [
+      ".gs"
+    ],
+    "example_ext": null,
+    "excluded_exts": [],
+    "reverse_exts": null,
+    "shebangs": [],
+    "is_target_language": true,
+    "tags": [
+      "is_proprietary"
+    ]
+  },
+  {
     "id": "hack",
     "name": "Hack",
     "keys": [

--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -903,6 +903,7 @@ $defs:
             - generic
             - go
             - golang
+            - gosu
             - hack
             - html
             - java


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
- [x] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged
